### PR TITLE
Contactor improvements

### DIFF
--- a/Software/BYD-CAN.cpp
+++ b/Software/BYD-CAN.cpp
@@ -87,6 +87,16 @@ void update_values_can_byd()
   //Temperature min
   BYD_210.data.u8[2] = (temperature_min >> 8);
   BYD_210.data.u8[3] = (temperature_min & 0x00FF);
+
+  //Indicate to inverter if BMS has encountered issues
+  if(bms_status == FAULT;)
+  {
+    BYD_190.data.u8[2] = 0x00; //We are not sure what this means, but battery control will be stopped for 5minutes if this is sent
+  }                            //Todo, maybe try other values and see if the inverter stops permanently until next reboot?
+  else
+  {
+    BYD_190.data.u8[2] = 0x03; //Indicates battery is OK to continue
+  }
 }
 
 void receive_can_byd(CAN_frame_t rx_frame)

--- a/Software/BYD-CAN.cpp
+++ b/Software/BYD-CAN.cpp
@@ -89,7 +89,7 @@ void update_values_can_byd()
   BYD_210.data.u8[3] = (temperature_min & 0x00FF);
 
   //Indicate to inverter if BMS has encountered issues
-  if(bms_status == FAULT;)
+  if(bms_status == FAULT)
   {
     BYD_190.data.u8[2] = 0x00; //We are not sure what this means, but battery control will be stopped for 5minutes if this is sent
   }                            //Todo, maybe try other values and see if the inverter stops permanently until next reboot?

--- a/Software/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/NISSAN-LEAF-BATTERY.cpp
@@ -327,6 +327,14 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame)
     LB_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);
     LB_Failsafe_Status = (rx_frame.data.u8[1] & 0x07);
     LB_MainRelayOn_flag = (byte) ((rx_frame.data.u8[3] & 0x20) >> 5);
+    if(LB_MainRelayOn_flag)
+    {
+      batteryAllowsContactorClosing = 1;
+    }
+    else
+    {
+      batteryAllowsContactorClosing = 0;
+    }
     LB_Full_CHARGE_flag = (byte) ((rx_frame.data.u8[3] & 0x10) >> 4);
     LB_Interlock = (byte) ((rx_frame.data.u8[3] & 0x08) >> 3);
     break;

--- a/Software/NISSAN-LEAF-BATTERY.h
+++ b/Software/NISSAN-LEAF-BATTERY.h
@@ -26,6 +26,7 @@ extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
+extern uint8_t batteryAllowsContactorClosing;
 // Definitions for BMS status
 #define STANDBY 0
 #define INACTIVE 1


### PR DESCRIPTION
Improve the code for contactor handling. Make BYD CAN safer

- Contactor startup sequence is now triggered when the LEAF BMS deems it OK to start
- Contactor opening (shutdown) is now handled incase the BMS sends a critical FAULT signal. LilyGo will have to be reset in order to re-engage the contactors. This is added as a safety feature. Only really critical errors result in FAULT state (over/undervoltage, loss of CAN, BMS sending emergency opening of contactors)
- BYD CAN message sending will be stoppped incase a FAULT is detected. This is done to signal to the inverter that some error state has occured. For now we don't know any error bits, so best to just stop sending CAN and force shutdown that way.