### PR TITLE
Add decimal to LB_Current

### DIFF
--- a/Software/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/NISSAN-LEAF-BATTERY.cpp
@@ -126,7 +126,7 @@ void update_values_leaf_battery()
 
   battery_voltage = (LB_Total_Voltage*10); //One more decimal needed
 
-  battery_current = LB_Current;
+  battery_current = (LB_Current*10); //One more decimal needed
 
 	capacity_Wh = (LB_Max_GIDS * WH_PER_GID);
 


### PR DESCRIPTION
Most inverters dont take raw Amps, so a +1 decimal is needed to the LB_Current value
Before, value sent as 1A
After, value sent as 1.0A (10)