### PR TITLE
Add timeout to CAN write to prevent crashing

### DIFF
--- a/Software/CAN.c
+++ b/Software/CAN.c
@@ -271,10 +271,7 @@ int CAN_write_frame(const CAN_frame_t *p_frame) {
 	// Write the frame to the controller
 	CAN_write_frame_phy(p_frame);
 
-	// wait for the frame tx to complete
-	xSemaphoreTake(sem_tx_complete, portMAX_DELAY);
-
-	return 0;
+	return xSemaphoreTake(sem_tx_complete, 20) == pdTRUE ? 0 : -1;
 }
 
 int CAN_stop() {

--- a/Software/ESP32CAN.cpp
+++ b/Software/ESP32CAN.cpp
@@ -1,4 +1,5 @@
 #include "ESP32CAN.h"
+#include <Arduino.h>
 
 int ESP32CAN::CANInit()
 {
@@ -6,7 +7,24 @@ int ESP32CAN::CANInit()
 }
 int ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame)
 {
-    return CAN_write_frame(p_frame);
+    static unsigned long start_time;
+    int result = -1;
+    if(tx_ok){
+        result = CAN_write_frame(p_frame);
+        tx_ok = (result == 0) ? true : false;
+        if(tx_ok == false){
+            Serial.println("CAN failure! Check wires");
+            LEDcolor = 3;
+            start_time = millis();
+        }
+    }
+    else{
+        if((millis() - start_time) >= 2000){
+            tx_ok = true;
+            LEDcolor = 0;
+        }
+    }
+    return result;
 }
 int ESP32CAN::CANStop()
 {

--- a/Software/ESP32CAN.h
+++ b/Software/ESP32CAN.h
@@ -3,14 +3,17 @@
 
 #include "CAN_config.h"
 #include "CAN.h"
+extern uint8_t LEDcolor;
 
 class ESP32CAN
 {
     public: 
+        bool tx_ok = true;
         int CANInit();
-		int CANConfigFilter(const CAN_filter_t* p_filter);
+		    int CANConfigFilter(const CAN_filter_t* p_filter);
         int CANWriteFrame(const CAN_frame_t* p_frame);
         int CANStop();
+        void CANSetCfg(CAN_device_t *can_cfg);
 };
 
 extern ESP32CAN ESP32Can;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -81,10 +81,12 @@ uint16_t stat_batt_power = 0; //power going in/out of battery
 #define GREEN 0
 #define YELLOW 1
 #define RED 2
+#define BLUE 3
+
 Adafruit_NeoPixel pixels(1, WS2812_PIN, NEO_GRB + NEO_KHZ800);
 static uint8_t brightness = 0;
 static bool rampUp = true;
-const uint8_t maxBrightness = 255;
+const uint8_t maxBrightness = 100;
 uint8_t LEDcolor = GREEN;
 
 //Contactor parameters
@@ -161,8 +163,6 @@ void setup()
 
   // Init LED control
   pixels.begin();
-  pixels.setPixelColor(0, pixels.Color(0, 0, 255)); // Blue LED full brightness while battery and CAN is starting. 
-  pixels.show();                                    // Incase of crash due to CAN polarity / termination, LED will remain BLUE
 
   //Inverter Setup
   #ifdef SOLAX_CAN
@@ -508,8 +508,11 @@ void handle_LED_state()
     case YELLOW:
     pixels.setPixelColor(0, pixels.Color(brightness, brightness, 0)); // Yellow pulsing LED
     break;
+    case BLUE:
+    pixels.setPixelColor(0, pixels.Color(0, 0, brightness)); //Blue pulsing LED
+    break;
     case RED:
-    pixels.setPixelColor(0, pixels.Color(255, 0, 0)); // Red LED full brightness
+    pixels.setPixelColor(0, pixels.Color(150, 0, 0)); // Red LED full brightness
     break;
     default:
     break;


### PR DESCRIPTION
⚠️ Safety improvement. This PR prevents the board from crashing incase a CAN write fails. 

It also changes:
- CAN failure state is now signaled with pulsing blue LED
- LED brightness decresed on normal states