### PR TITLE
Tesla 3 contactor opening

### DIFF
--- a/Software/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/NISSAN-LEAF-BATTERY.cpp
@@ -513,6 +513,9 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame)
 
         cell_deviation_mV = (min_max_voltage[1] - min_max_voltage[0]);
 
+        cell_max_voltage = min_max_voltage[1]; 
+        cell_min_voltage = min_max_voltage[0];
+
         if(cell_deviation_mV > MAX_CELL_DEVIATION){
           LEDcolor = YELLOW;
           Serial.println("HIGH CELL DEVIATION!!! Inspect battery!");

--- a/Software/NISSAN-LEAF-BATTERY.h
+++ b/Software/NISSAN-LEAF-BATTERY.h
@@ -21,6 +21,8 @@ extern uint16_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
+extern uint16_t cell_max_voltage;
+extern uint16_t cell_min_voltage;
 extern uint8_t batteryAllowsContactorClosing;
 extern uint8_t LEDcolor;
 // Definitions for BMS status

--- a/Software/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/TESLA-MODEL-3-BATTERY.cpp
@@ -121,6 +121,10 @@ void update_values_tesla_model_3_battery()
   max_temp = (max_temp * 10);
 	temperature_max = convert2unsignedint16(max_temp);
 
+  cell_max_voltage = cell_max_v;
+
+  cell_min_voltage = cell_min_v;
+
   /* Value mapping is completed. Start to check all safeties */
 
   bms_status = ACTIVE; //Startout in active mode before checking if we have any faults

--- a/Software/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/TESLA-MODEL-3-BATTERY.cpp
@@ -105,13 +105,12 @@ void update_values_tesla_model_3_battery()
     max_target_discharge_power = temporaryvariable;
   }
 
-  //Calculate the allowed charge power, cap it if it gets too large
-	temporaryvariable = (max_charge_current * volts);
-	if(temporaryvariable > 60000){
-    max_target_charge_power = 60000;
+  //The allowed charge power behaves strangely. We instead estimate this value
+	if(SOC == 10000){
+    max_target_charge_power = 0; //When battery is 100% full, set allowed charge W to 0
   }
   else{
-    max_target_charge_power = temporaryvariable;
+    max_target_charge_power = 15000; //Otherwise we can push 15kW into the pack!
   }
 
 	stat_batt_power = (volts * amps); //TODO, check if scaling is OK

--- a/Software/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/TESLA-MODEL-3-BATTERY.cpp
@@ -137,6 +137,11 @@ void update_values_tesla_model_3_battery()
 	stillAliveCAN--;
 	}
 
+  if (hvil_status == 3){ //INTERNAL_OPEN_FAULT - Someone disconnected a high voltage cable while battery was in use
+    bms_status = FAULT;
+    Serial.println("High voltage cable removed while battery running. Opening contactors!");
+  } 
+
   if(cell_max_v >= MAX_CELL_VOLTAGE){ 
     bms_status = FAULT;
     Serial.println("CELL OVERVOLTAGE!!! Stopping battery charging and discharging. Inspect battery!");

--- a/Software/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/TESLA-MODEL-3-BATTERY.cpp
@@ -364,14 +364,11 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
       ESP32Can.CANWriteFrame(&TESLA_221_1);
       ESP32Can.CANWriteFrame(&TESLA_221_2);
     }
-    else if(bms_status == FAULT){
+    else{ //bms_status == FAULT
       if(send221still > 0){
         ESP32Can.CANWriteFrame(&TESLA_221_1);
         send221still--;
       }
-    }
-    else{
-      //Updating or some other state we dont use
     }
 	}
 }

--- a/Software/TESLA-MODEL-3-BATTERY.h
+++ b/Software/TESLA-MODEL-3-BATTERY.h
@@ -22,6 +22,8 @@ extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
+extern uint16_t cell_max_voltage;
+extern uint16_t cell_min_voltage;
 extern uint8_t LEDcolor;
 // Definitions for BMS status
 #define STANDBY 0


### PR DESCRIPTION
- CAN still alive now read from BMS message
- Add contactor opening incase of a FAULT situation
- Add HVIL safety
- Cell voltages now mapped to inverter values (both Tesla and Nissan LEAF)
- Charge max value for Tesla Model3 now estimated