### PR TITLE
Leaf leafspy

### DIFF
--- a/Software/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/NISSAN-LEAF-BATTERY.cpp
@@ -369,6 +369,8 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame)
       // negative so extend the sign bit
       LB_Current |= 0xf800;
     }
+    // Scale down the value by 0.5
+    LB_Current /= 2;
 
     LB_Total_Voltage = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6) / 2;
     

--- a/Software/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/NISSAN-LEAF-BATTERY.cpp
@@ -340,18 +340,10 @@ void update_values_leaf_battery()
     Serial.println(min_max_voltage[1]);
     Serial.print("Cell deviation: ");
     Serial.println(cell_deviation_mV);
-    Serial.print("Temperatures; Polled temp min: ");
-    Serial.print(temp_polled_min);
-    Serial.print(" Polled temp max: ");
-    Serial.print(temp_polled_max);
-    Serial.print(" 5C0 temp max: ");
-    Serial.print(LB_HistData_Temperature_MAX);
-    Serial.print(" 5C0 temp min: ");
-    Serial.println(LB_HistData_Temperature_MIN);
-    Serial.print("Current 1: ");
-    Serial.print(Battery_current_1);
-    Serial.print(" Current 2: ");
-    Serial.println(Battery_current_2);
+    Serial.print("Temperature to inverter; min: ");
+    Serial.print(temperature_min);
+    Serial.print(" max: ");
+    Serial.println(temperature_max);
   #endif
 }
 


### PR DESCRIPTION
This PR fixes the following for the Nissan LEAF packs

- Active polling now paused for 100s when Leafspy detected. 
- Fixed an issue where LED became yellow if Leafspy was turned on while cell monitoring was performed.
- Added error code 10, when too many corrupted CAN messages detected
- Fixed scaling of LB_Current, A/W values no longer show 2x the real amount
- Only the temperature min/max values used by the inverter are printed to USB