### PR TITLE
Tesla Model3 debug improvements

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -42,6 +42,7 @@ static uint16_t output_current = 0;
 static uint16_t soc_min = 0;
 static uint16_t soc_max = 0;
 static uint16_t soc_vi = 0;
+static uint16_t soc_calculated = 0;
 static uint16_t soc_ave = 0;
 static uint16_t cell_max_v = 3700;
 static uint16_t cell_min_v = 3700;
@@ -89,16 +90,17 @@ void update_values_tesla_model_3_battery()
 	StateOfHealth = 9900; //Hardcoded to 99%SOH
 
   //Calculate the SOC% value to send to inverter
-  soc_vi = MIN_SOC + (MAX_SOC - MIN_SOC) * (soc_vi - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE); 
-  if (soc_vi < 0)
+  soc_calculated = soc_vi;
+  soc_calculated = MIN_SOC + (MAX_SOC - MIN_SOC) * (soc_calculated - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE); 
+  if (soc_calculated < 0)
   { //We are in the real SOC% range of 0-20%, always set SOC sent to Inverter as 0%
-      soc_vi = 0;
+      soc_calculated = 0;
   }
-  if (soc_vi > 1000)
+  if (soc_calculated > 1000)
   { //We are in the real SOC% range of 80-100%, always set SOC sent to Inverter as 100%
-      soc_vi = 1000;
+      soc_calculated = 1000;
   }
-  SOC = (soc_vi * 10); //increase SOC range from 0-100.0 -> 100.00
+  SOC = (soc_calculated * 10); //increase SOC range from 0-100.0 -> 100.00
 
 	battery_voltage = (volts*10); //One more decimal needed (370 -> 3700)
 
@@ -205,21 +207,14 @@ void update_values_tesla_model_3_battery()
     Serial.println(pyroTestInProgress);
 
     Serial.print("Battery values: ");
-    Serial.print(" Vi SOC: ");
+    Serial.print("Real SOC: ");
     Serial.print(soc_vi);
-    Serial.print(", SOC max: ");
-    Serial.print(soc_max);
-    Serial.print(", SOC min: ");
-    Serial.print(soc_min);
-    Serial.print(", SOC avg: ");
-    Serial.print(soc_ave);
     print_int_with_units(", Battery voltage: ", volts, "V");
     print_int_with_units(", Battery current: ", amps, "A");
     Serial.println("");
     print_int_with_units("Discharge limit battery: ", discharge_limit, "kW");
     Serial.print(", ");
     print_int_with_units("Charge limit battery: ", regenerative_limit, "kW");
-    Serial.print("kW");
     Serial.print(", Fully charged?: ");
     if(full_charge_complete)
       Serial.print("YES, ");

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -555,11 +555,11 @@ void printFaultCodesIfActive(){
   printDebugIfActive(SecondaryBmbMiaFault, "ERROR: voltage and temperature readings from secondary BMB chain are mia");
   printDebugIfActive(BmbMismatchFault, "ERROR: primary and secondary BMB chain readings don't match with each other");
   printDebugIfActive(BmsHviMiaFault, "ERROR: BMS node is mia on HVS or HVI CAN");
-  printDebugIfActive(CpMiaFault, "ERROR: CP node is mia on HVS CAN");
+  //printDebugIfActive(CpMiaFault, "ERROR: CP node is mia on HVS CAN"); //Uncommented due to not affecting usage
   printDebugIfActive(PcsMiaFault, "ERROR: PCS node is mia on HVS CAN");
-  printDebugIfActive(BmsFault, "ERROR: BmsFault is active");
+  //printDebugIfActive(BmsFault, "ERROR: BmsFault is active"); //Uncommented due to not affecting usage
   printDebugIfActive(PcsFault, "ERROR: PcsFault is active");
-  printDebugIfActive(CpFault, "ERROR: CpFault is active");
+  //printDebugIfActive(CpFault, "ERROR: CpFault is active"); //Uncommented due to not affecting usage
   printDebugIfActive(ShuntHwMiaFault, "ERROR: shunt current reading is not available");
   printDebugIfActive(PyroMiaFault, "ERROR: pyro squib is not connected");
   printDebugIfActive(hvsMiaFault, "ERROR: pack contactor hw fault");
@@ -569,7 +569,7 @@ void printFaultCodesIfActive(){
   printDebugIfActive(HvilFault, "ERROR: High Voltage Inter Lock fault is detected");
   printDebugIfActive(BmsHvsMiaFault, "ERROR: BMS node is mia on HVS or HVI CAN");
   printDebugIfActive(PackVoltMismatchFault, "ERROR: Pack voltage doesn't match approximately with sum of brick voltages");
-  printDebugIfActive(EnsMiaFault, "ERROR: ENS line is not connected to HVC");
+  //printDebugIfActive(EnsMiaFault, "ERROR: ENS line is not connected to HVC"); //Uncommented due to not affecting usage
   printDebugIfActive(PackPosCtrArcFault, "ERROR: HVP detectes series arc at pack contactor");
   printDebugIfActive(packNegCtrArcFault, "ERROR: HVP detectes series arc at FC contactor");
   printDebugIfActive(ShuntHwAndBmsMiaFault, "ERROR: ShuntHwAndBmsMiaFault is active");
@@ -578,7 +578,7 @@ void printFaultCodesIfActive(){
   printDebugIfActive(packContHwFault, "ERROR: packContHwFault is active");
   printDebugIfActive(pyroFuseBlown, "ERROR: pyroFuseBlown is active");
   printDebugIfActive(pyroFuseFailedToBlow, "ERROR: pyroFuseFailedToBlow is active");
-  printDebugIfActive(CpilFault, "ERROR: CpilFault is active");
+  //printDebugIfActive(CpilFault, "ERROR: CpilFault is active"); //Uncommented due to not affecting usage
   printDebugIfActive(PackContactorFellOpen, "ERROR: PackContactorFellOpen is active");
   printDebugIfActive(FcContactorFellOpen, "ERROR: FcContactorFellOpen is active");
   printDebugIfActive(packCtrCloseBlocked, "ERROR: packCtrCloseBlocked is active");

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -40,6 +40,10 @@ extern uint8_t LEDcolor;
 void update_values_tesla_model_3_battery();
 void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame);
 void send_can_tesla_model_3_battery();
+void printFaultCodesIfActive();
+void printDebugIfActive(uint8_t symbol, const char* message);
+void print_int_with_units(char *header, int value, char *units);
+void print_SOC(char *header, int SOC);
 uint16_t convert2unsignedInt16(int16_t signed_value);
 
 #endif


### PR DESCRIPTION
This PR adds the following new functionality/fixes for the Tesla batteries
- Autodetect LFP or NCA/NCM chemistry. 🔋  These two battery types have different voltage limits, and the code now can select the correct limits automatically
- 50 new fault codes added! ⚠️ The error matrix from 0x3AA is now fully decoded, and the software will alert you if one of them is triggered. Example, `"ERROR: Pack discharge current is above the safe max discharge current limit!"` and another example, `"ERROR: shunt current reading is not available"`
- RealSOC now visible in the USB printout. Previously this value was overwritten instantly by the rescaled value heading towards inverter