### PR TITLE
Update file naming and macro naming for consistency, add missing notifications for PYLON_CAN and CHADEMO_BATTERY

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -200,10 +200,8 @@ void setup()
   pixels.begin();
 
   //Inform user what Inverter is used
-  #ifdef SOLAX_CAN
-  inverterAllowsContactorClosing = 0; //The inverter needs to allow first on this protocol
-  intervalInverterTask = 800; //This protocol also requires the values to be updated faster
-  Serial.println("SOLAX CAN protocol selected");
+  #ifdef BYD_CAN
+  Serial.println("BYD CAN protocol selected");
   #endif
   #ifdef BYD_MODBUS
   Serial.println("BYD Modbus RTU protocol selected");
@@ -211,25 +209,18 @@ void setup()
   #ifdef LUNA2000_MODBUS
   Serial.println("Luna2000 Modbus RTU protocol selected");
   #endif
-  #ifdef BYD_CAN
-  Serial.println("BYD CAN protocol selected");
-  #endif
   #ifdef SMA_CAN
   Serial.println("SMA CAN protocol selected");
   #endif
   #ifdef SOFAR_CAN
   Serial.println("SOFAR CAN protocol selected");
   #endif
-  //Inform user what battery is used
-  #ifdef NISSAN_LEAF_BATTERY
-  Serial.println("Nissan LEAF battery selected");
-  #endif 
-  #ifdef TESLA_MODEL_3_BATTERY
-  Serial.println("Tesla Model 3 battery selected");
-  #endif 
-  #ifdef RENAULT_ZOE_BATTERY
-  Serial.println("Renault Zoe / Kangoo battery selected");
+  #ifdef SOLAX_CAN
+  inverterAllowsContactorClosing = 0; //The inverter needs to allow first on this protocol
+  intervalInverterTask = 800; //This protocol also requires the values to be updated faster
+  Serial.println("SOLAX CAN protocol selected");
   #endif
+  //Inform user what battery is used
   #ifdef BMW_I3_BATTERY
   Serial.println("BMW i3 battery selected");
   #endif
@@ -238,6 +229,15 @@ void setup()
   #endif
   #ifdef KIA_HYUNDAI_64_BATTERY
   Serial.println("Kia Niro / Hyundai Kona 64kWh battery selected");
+  #endif
+  #ifdef NISSAN_LEAF_BATTERY
+  Serial.println("Nissan LEAF battery selected");
+  #endif
+  #ifdef RENAULT_ZOE_BATTERY
+  Serial.println("Renault Zoe / Kangoo battery selected");
+  #endif
+  #ifdef TESLA_MODEL_3_BATTERY
+  Serial.println("Tesla Model 3 battery selected");
   #endif
 }
 
@@ -275,17 +275,12 @@ void handle_can()
     if (rx_frame.FIR.B.FF == CAN_frame_std)
     {
       //printf("New standard frame");
-      #ifdef NISSAN_LEAF_BATTERY
-      receive_can_leaf_battery(rx_frame);
-      #endif 
-      #ifdef TESLA_MODEL_3_BATTERY
-      receive_can_tesla_model_3_battery(rx_frame); 
-      #endif
-      #ifdef RENAULT_ZOE_BATTERY
-      receive_can_zoe_battery(rx_frame);
-      #endif
+      // battery
       #ifdef BMW_I3_BATTERY
       receive_can_i3_battery(rx_frame);
+      #endif
+      #ifdef CHADEMO_BATTERY
+      receive_can_chademo(rx_frame);
       #endif
       #ifdef IMIEV_CZERO_ION_BATTERY
       receive_can_imiev_battery(rx_frame);
@@ -293,27 +288,34 @@ void handle_can()
       #ifdef KIA_HYUNDAI_64_BATTERY
       receive_can_kiaHyundai_64_battery(rx_frame);
       #endif
+      #ifdef NISSAN_LEAF_BATTERY
+      receive_can_leaf_battery(rx_frame);
+      #endif 
+      #ifdef RENAULT_ZOE_BATTERY
+      receive_can_zoe_battery(rx_frame);
+      #endif
+      #ifdef TESLA_MODEL_3_BATTERY
+      receive_can_tesla_model_3_battery(rx_frame); 
+      #endif
+      // inverter
       #ifdef BYD_CAN
       receive_can_byd(rx_frame);
       #endif
       #ifdef SMA_CAN
       receive_can_sma(rx_frame);
       #endif
-	  #ifdef CHADEMO_BATTERY
-      receive_can_chademo(rx_frame);
-      #endif
     }
     else
     {
       //printf("New extended frame");
+      #ifdef PYLON_CAN
+      receive_can_pylon(rx_frame);
+      #endif
+      #ifdef SOFAR_CAN
+      receive_can_sofar(rx_frame);
+      #endif
       #ifdef SOLAX_CAN
       receive_can_solax(rx_frame);
-      #endif
-	  #ifdef PYLON_CAN
-	  receive_can_pylon(rx_frame);
-	  #endif
-	  #ifdef SOFAR_CAN
-      receive_can_sofar(rx_frame);
       #endif
     }
   }
@@ -329,17 +331,11 @@ void handle_can()
   send_can_sofar();
   #endif
   //Battery sending
-  #ifdef NISSAN_LEAF_BATTERY
-  send_can_leaf_battery();
-	#endif 
-  #ifdef TESLA_MODEL_3_BATTERY
-  send_can_tesla_model_3_battery(); 
-  #endif
-  #ifdef RENAULT_ZOE_BATTERY
-  send_can_zoe_battery();
-  #endif
   #ifdef BMW_I3_BATTERY
   send_can_i3_battery();
+  #endif
+  #ifdef CHADEMO_BATTERY
+  send_can_chademo_battery();
   #endif
   #ifdef IMIEV_CZERO_ION_BATTERY
   send_can_imiev_battery();
@@ -347,8 +343,14 @@ void handle_can()
   #ifdef KIA_HYUNDAI_64_BATTERY 
   send_can_kiaHyundai_64_battery();
   #endif
-  #ifdef CHADEMO_BATTERY
-  send_can_chademo_battery();
+  #ifdef NISSAN_LEAF_BATTERY
+  send_can_leaf_battery();
+	#endif 
+  #ifdef RENAULT_ZOE_BATTERY
+  send_can_zoe_battery();
+  #endif
+  #ifdef TESLA_MODEL_3_BATTERY
+  send_can_tesla_model_3_battery(); 
   #endif
 }
 
@@ -381,12 +383,12 @@ void handle_can()
     else
     {
       //Serial.println("New extended frame");
-      #ifdef SOLAX_CAN
-      receive_can_solax(rx_frame2);
-      #endif
 	    #ifdef PYLON_CAN
 	    receive_can_pylon(rx_frame2);
 	    #endif
+      #ifdef SOLAX_CAN
+      receive_can_solax(rx_frame2);
+      #endif
     }
   }
   //When we are done checking if a CAN message has arrived, we can focus on sending CAN messages
@@ -399,17 +401,12 @@ void handle_can()
 
 void handle_inverter()
 {
-	  #ifdef NISSAN_LEAF_BATTERY
-    update_values_leaf_battery(); //Map the values to the correct registers
-	  #endif 
-    #ifdef TESLA_MODEL_3_BATTERY
-    update_values_tesla_model_3_battery(); //Map the values to the correct registers
-    #endif
-    #ifdef RENAULT_ZOE_BATTERY
-    update_values_zoe_battery(); //Map the values to the correct registers
-    #endif
+	  // battery
     #ifdef BMW_I3_BATTERY
     update_values_i3_battery(); //Map the values to the correct registers
+    #endif
+	  #ifdef CHADEMO_BATTERY
+    update_values_can_chademo();
     #endif
     #ifdef IMIEV_CZERO_ION_BATTERY
     update_values_imiev_battery(); //Map the values to the correct registers
@@ -417,27 +414,33 @@ void handle_inverter()
     #ifdef KIA_HYUNDAI_64_BATTERY
     update_values_kiaHyundai_64_battery(); //Map the values to the correct registers
     #endif
-    #ifdef SOLAX_CAN
-    update_values_can_solax();
+    #ifdef NISSAN_LEAF_BATTERY
+    update_values_leaf_battery(); //Map the values to the correct registers
+	  #endif
+    #ifdef RENAULT_ZOE_BATTERY
+    update_values_zoe_battery(); //Map the values to the correct registers
     #endif
+    #ifdef TESLA_MODEL_3_BATTERY
+    update_values_tesla_model_3_battery(); //Map the values to the correct registers
+    #endif
+    // inverter
     #ifdef BYD_CAN
     update_values_can_byd();
     #endif
-    #ifdef SMA_CAN
-    update_values_can_sma();
-    #endif
-    #ifdef PYLON_CAN
-    update_values_can_pylon();
-    #endif
-	  #ifdef CHADEMO_BATTERY
-    update_values_can_chademo();
-    #endif
-
     #ifdef BYD_MODBUS
     update_modbus_registers_byd();
     #endif
     #ifdef LUNA2000_MODBUS
     update_modbus_registers_luna2000();
+    #endif
+    #ifdef PYLON_CAN
+    update_values_can_pylon();
+    #endif
+    #ifdef SMA_CAN
+    update_values_can_sma();
+    #endif
+    #ifdef SOLAX_CAN
+    update_values_can_solax();
     #endif
 }
 

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -209,6 +209,9 @@ void setup()
   #ifdef LUNA2000_MODBUS
   Serial.println("Luna2000 Modbus RTU protocol selected");
   #endif
+  #ifdef PYLON_CAN
+  Serial.println("PYLON CAN protocol selected") 
+  #endif
   #ifdef SMA_CAN
   Serial.println("SMA CAN protocol selected");
   #endif
@@ -223,6 +226,9 @@ void setup()
   //Inform user what battery is used
   #ifdef BMW_I3_BATTERY
   Serial.println("BMW i3 battery selected");
+  #endif
+  #ifdef CHADEMO_BATTERY
+  Serial.println("Chademo battery selected");
   #endif
   #ifdef IMIEV_CZERO_ION_BATTERY
   Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -32,13 +32,13 @@ unsigned long previousMillis10ms = 50;
 unsigned long previousMillisInverter = 0; 
 
 //ModbusRTU parameters
-#if defined(MODBUS_BYD)
+#if defined(BYD_MODBUS)
 #define MB_RTU_NUM_VALUES 30000
 #endif
-#if defined(MODBUS_LUNA2000)
+#if defined(LUNA2000_MODBUS)
 #define MB_RTU_NUM_VALUES 50000
 #endif
-#if defined(MODBUS_BYD) || defined(MODBUS_LUNA2000)
+#if defined(BYD_MODBUS) || defined(LUNA2000_MODBUS)
 uint16_t mbPV[MB_RTU_NUM_VALUES];  // process variable memory
 // Create a ModbusRTU server instance listening on Serial2 with 2000ms timeout
 ModbusServerRTU MBserver(Serial2, 2000);
@@ -179,11 +179,11 @@ void setup()
   pinMode(PIN_5V_EN, OUTPUT);
   digitalWrite(PIN_5V_EN, HIGH);
 
-  #ifdef MODBUS_BYD
+  #ifdef BYD_MODBUS
   // Init Static data to the RTU Modbus
   handle_static_data_modbus_byd();
   #endif
-  #if defined(MODBUS_BYD) || defined(MODBUS_LUNA2000)
+  #if defined(BYD_MODBUS) || defined(LUNA2000_MODBUS)
   // Init Serial2 connected to the RTU Modbus
   RTUutils::prepareHardwareSerial(Serial2);
   Serial2.begin(9600, SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
@@ -205,13 +205,13 @@ void setup()
   intervalInverterTask = 800; //This protocol also requires the values to be updated faster
   Serial.println("SOLAX CAN protocol selected");
   #endif
-  #ifdef MODBUS_BYD
+  #ifdef BYD_MODBUS
   Serial.println("BYD Modbus RTU protocol selected");
   #endif
-  #ifdef MODBUS_LUNA2000
+  #ifdef LUNA2000_MODBUS
   Serial.println("Luna2000 Modbus RTU protocol selected");
   #endif
-  #ifdef CAN_BYD
+  #ifdef BYD_CAN
   Serial.println("BYD CAN protocol selected");
   #endif
   #ifdef SMA_CAN
@@ -221,7 +221,7 @@ void setup()
   Serial.println("SOFAR CAN protocol selected");
   #endif
   //Inform user what battery is used
-  #ifdef BATTERY_TYPE_LEAF
+  #ifdef NISSAN_LEAF_BATTERY
   Serial.println("Nissan LEAF battery selected");
   #endif 
   #ifdef TESLA_MODEL_3_BATTERY
@@ -233,7 +233,7 @@ void setup()
   #ifdef BMW_I3_BATTERY
   Serial.println("BMW i3 battery selected");
   #endif
-  #ifdef IMIEV_ION_CZERO_BATTERY
+  #ifdef IMIEV_CZERO_ION_BATTERY
   Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");
   #endif
   #ifdef KIA_HYUNDAI_64_BATTERY
@@ -275,7 +275,7 @@ void handle_can()
     if (rx_frame.FIR.B.FF == CAN_frame_std)
     {
       //printf("New standard frame");
-      #ifdef BATTERY_TYPE_LEAF
+      #ifdef NISSAN_LEAF_BATTERY
       receive_can_leaf_battery(rx_frame);
       #endif 
       #ifdef TESLA_MODEL_3_BATTERY
@@ -287,19 +287,19 @@ void handle_can()
       #ifdef BMW_I3_BATTERY
       receive_can_i3_battery(rx_frame);
       #endif
-      #ifdef IMIEV_ION_CZERO_BATTERY
+      #ifdef IMIEV_CZERO_ION_BATTERY
       receive_can_imiev_battery(rx_frame);
       #endif
       #ifdef KIA_HYUNDAI_64_BATTERY
       receive_can_kiaHyundai_64_battery(rx_frame);
       #endif
-      #ifdef CAN_BYD
+      #ifdef BYD_CAN
       receive_can_byd(rx_frame);
       #endif
       #ifdef SMA_CAN
       receive_can_sma(rx_frame);
       #endif
-	  #ifdef CHADEMO
+	  #ifdef CHADEMO_BATTERY
       receive_can_chademo(rx_frame);
       #endif
     }
@@ -319,7 +319,7 @@ void handle_can()
   }
   //When we are done checking if a CAN message has arrived, we can focus on sending CAN messages
   //Inverter sending
-  #ifdef CAN_BYD
+  #ifdef BYD_CAN
   send_can_byd();
   #endif
   #ifdef SMA_CAN
@@ -329,7 +329,7 @@ void handle_can()
   send_can_sofar();
   #endif
   //Battery sending
-  #ifdef BATTERY_TYPE_LEAF
+  #ifdef NISSAN_LEAF_BATTERY
   send_can_leaf_battery();
 	#endif 
   #ifdef TESLA_MODEL_3_BATTERY
@@ -341,13 +341,13 @@ void handle_can()
   #ifdef BMW_I3_BATTERY
   send_can_i3_battery();
   #endif
-  #ifdef IMIEV_ION_CZERO_BATTERY
+  #ifdef IMIEV_CZERO_ION_BATTERY
   send_can_imiev_battery();
   #endif
   #ifdef KIA_HYUNDAI_64_BATTERY 
   send_can_kiaHyundai_64_battery();
   #endif
-  #ifdef CHADEMO
+  #ifdef CHADEMO_BATTERY
   send_can_chademo_battery();
   #endif
 }
@@ -374,7 +374,7 @@ void handle_can()
     if (rx_frame2.FIR.B.FF == CAN_frame_std)
     {
       //Serial.println("New standard frame");
-      #ifdef CAN_BYD
+      #ifdef BYD_CAN
       receive_can_byd(rx_frame2);
       #endif
     }
@@ -391,7 +391,7 @@ void handle_can()
   }
   //When we are done checking if a CAN message has arrived, we can focus on sending CAN messages
   //Inverter sending
-  #ifdef CAN_BYD
+  #ifdef BYD_CAN
   send_can_byd();
   #endif
 }
@@ -399,7 +399,7 @@ void handle_can()
 
 void handle_inverter()
 {
-	  #ifdef BATTERY_TYPE_LEAF
+	  #ifdef NISSAN_LEAF_BATTERY
     update_values_leaf_battery(); //Map the values to the correct registers
 	  #endif 
     #ifdef TESLA_MODEL_3_BATTERY
@@ -411,7 +411,7 @@ void handle_inverter()
     #ifdef BMW_I3_BATTERY
     update_values_i3_battery(); //Map the values to the correct registers
     #endif
-    #ifdef IMIEV_ION_CZERO_BATTERY
+    #ifdef IMIEV_CZERO_ION_BATTERY
     update_values_imiev_battery(); //Map the values to the correct registers
     #endif
     #ifdef KIA_HYUNDAI_64_BATTERY
@@ -420,7 +420,7 @@ void handle_inverter()
     #ifdef SOLAX_CAN
     update_values_can_solax();
     #endif
-    #ifdef CAN_BYD
+    #ifdef BYD_CAN
     update_values_can_byd();
     #endif
     #ifdef SMA_CAN
@@ -429,14 +429,14 @@ void handle_inverter()
     #ifdef PYLON_CAN
     update_values_can_pylon();
     #endif
-	  #ifdef CHADEMO
+	  #ifdef CHADEMO_BATTERY
     update_values_can_chademo();
     #endif
 
-    #ifdef MODBUS_BYD
+    #ifdef BYD_MODBUS
     update_modbus_registers_byd();
     #endif
-    #ifdef MODBUS_LUNA2000
+    #ifdef LUNA2000_MODBUS
     update_modbus_registers_luna2000();
     #endif
 }

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -6,18 +6,18 @@
 /* There are also some options for battery limits and extra functionality */
 
 /* Select battery used */
-#define BATTERY_TYPE_LEAF
+#define NISSAN_LEAF_BATTERY
 //#define TESLA_MODEL_3_BATTERY
 //#define RENAULT_ZOE_BATTERY
 //#define BMW_I3_BATTERY
-//#define IMIEV_ION_CZERO_BATTERY
+//#define IMIEV_CZERO_ION_BATTERY
 //#define KIA_HYUNDAI_64_BATTERY
-//#define CHADEMO
+//#define CHADEMO_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
-#define MODBUS_BYD     //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
-//#define MODBUS_LUNA2000   //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
-//#define CAN_BYD      //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+#define BYD_MODBUS     //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+//#define LUNA2000_MODBUS   //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
+//#define BYD_CAN      //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
 //#define SOLAX_CAN    //Enable this line to emulate a "SolaX Triple Power LFP" over CAN bus
 //#define PYLON_CAN		 //Enable this line to emulate a "Pylontech battery" over CAN bus
 //#define SMA_CAN		  //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -6,22 +6,22 @@
 /* There are also some options for battery limits and extra functionality */
 
 /* Select battery used */
-#define NISSAN_LEAF_BATTERY
-//#define TESLA_MODEL_3_BATTERY
-//#define RENAULT_ZOE_BATTERY
 //#define BMW_I3_BATTERY
+//#define CHADEMO_BATTERY
 //#define IMIEV_CZERO_ION_BATTERY
 //#define KIA_HYUNDAI_64_BATTERY
-//#define CHADEMO_BATTERY
+#define NISSAN_LEAF_BATTERY
+//#define RENAULT_ZOE_BATTERY
+//#define TESLA_MODEL_3_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
-#define BYD_MODBUS     //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
-//#define LUNA2000_MODBUS   //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
-//#define BYD_CAN      //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-//#define SOLAX_CAN    //Enable this line to emulate a "SolaX Triple Power LFP" over CAN bus
-//#define PYLON_CAN		 //Enable this line to emulate a "Pylontech battery" over CAN bus
-//#define SMA_CAN		  //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus
-//#define SOFAR_CAN   //Enable this line to emulate a "Sofar Energy Storage Inverter High Voltage BMS General Protocol (Extended Frame)" over CAN bus
+//#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+//#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
+//#define PYLON_CAN	       //Enable this line to emulate a "Pylontech battery" over CAN bus
+//#define SMA_CAN          //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus
+//#define SOFAR_CAN        //Enable this line to emulate a "Sofar Energy Storage Inverter High Voltage BMS General Protocol (Extended Frame)" over CAN bus
+//#define SOLAX_CAN        //Enable this line to emulate a "SolaX Triple Power LFP" over CAN bus
 
 /* Battery settings */
 #define BATTERY_WH_MAX 30000 //Battery size in Wh (Maximum value for most inverters is 60000 [60kWh], you can use larger batteries but do set value over 60000!

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -1,23 +1,15 @@
 #ifndef BATTERIES_H
 #define BATTERIES_H
 
-#ifdef BATTERY_TYPE_LEAF
-  #include "NISSAN-LEAF-BATTERY.h" //See this file for more LEAF battery settings
-#endif
-
-#ifdef TESLA_MODEL_3_BATTERY
-  #include "TESLA-MODEL-3-BATTERY.h" //See this file for more Tesla battery settings
-#endif
-
-#ifdef RENAULT_ZOE_BATTERY
-  #include "RENAULT-ZOE-BATTERY.h" //See this file for more Zoe battery settings
-#endif
-
 #ifdef BMW_I3_BATTERY
   #include "BMW-I3-BATTERY.h" //See this file for more i3 battery settings
 #endif
 
-#ifdef IMIEV_ION_CZERO_BATTERY
+#ifdef CHADEMO_BATTERY
+	#include "CHADEMO-BATTERY.h" //See this file for more Chademo settings
+#endif
+
+#ifdef IMIEV_CZERO_ION_BATTERY
   #include "IMIEV-CZERO-ION-BATTERY.h" //See this file for more triplet battery settings
 #endif
 
@@ -25,8 +17,16 @@
   #include "KIA-HYUNDAI-64-BATTERY.h" //See this file for more 64kWh battery settings
 #endif
 
-#ifdef CHADEMO
-	#include "CHADEMO-BATTERY.h" //See this file for more Chademo settings
+#ifdef NISSAN_LEAF_BATTERY
+  #include "NISSAN-LEAF-BATTERY.h" //See this file for more LEAF battery settings
+#endif
+
+#ifdef RENAULT_ZOE_BATTERY
+  #include "RENAULT-ZOE-BATTERY.h" //See this file for more Zoe battery settings
+#endif
+
+#ifdef TESLA_MODEL_3_BATTERY
+  #include "TESLA-MODEL-3-BATTERY.h" //See this file for more Tesla battery settings
 #endif
 
 #endif

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -1,4 +1,4 @@
-#include "MODBUS-BYD.h"
+#include "BYD-MODBUS.h"
 
 void update_modbus_registers_byd() {
     //Updata for ModbusRTU Server for BYD

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -1,8 +1,8 @@
-#ifndef MODBUS_LUNA2000_H
-#define MODBUS_LUNA2000_H
+#ifndef BYD_MODBUS_H
+#define BYD_MODBUS_H
 #include <Arduino.h>
 
-#define MB_RTU_NUM_VALUES 50000
+#define MB_RTU_NUM_VALUES 30000
 // Definitions for BMS status
 #define STANDBY 0
 #define INACTIVE 1
@@ -31,7 +31,8 @@ extern uint16_t max_power;
 extern uint16_t max_volt_modbus_byd;
 extern uint16_t min_volt_modbus_byd;
 
-void update_modbus_registers_luna2000();
-void handle_update_data_modbus32051();
-void handle_update_data_modbus39500();
+void handle_static_data_modbus_byd();
+void handle_update_data_modbusp201_byd();
+void handle_update_data_modbusp301_byd();
+void update_modbus_registers_byd();
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -1,12 +1,20 @@
 #ifndef INVERTERS_H
 #define INVERTERS_H
 
-#ifdef SOLAX_CAN
-  #include "SOLAX-CAN.h"
+#ifdef BYD_CAN
+  #include "BYD-CAN.h"
 #endif
 
-#ifdef CAN_BYD
-  #include "BYD-CAN.h"
+#ifdef BYD_MODBUS
+  #include "BYD-MODBUS.h"
+#endif
+
+#ifdef LUNA2000_MODBUS
+  #include "LUNA2000-MODBUS.h"
+#endif
+
+#ifdef PYLON_CAN
+  #include "PYLON-CAN.h"
 #endif
 
 #ifdef SMA_CAN
@@ -17,16 +25,8 @@
   #include "SOFAR-CAN.h"
 #endif
 
-#ifdef PYLON_CAN
-  #include "PYLON-CAN.h"
-#endif
-
-#ifdef MODBUS_BYD
-  #include "MODBUS-BYD.h"
-#endif
-
-#ifdef MODBUS_LUNA2000
-  #include "MODBUS-LUNA2000.h"
+#ifdef SOLAX_CAN
+  #include "SOLAX-CAN.h"
 #endif
 
 #endif

--- a/Software/src/inverter/LUNA2000-MODBUS.cpp
+++ b/Software/src/inverter/LUNA2000-MODBUS.cpp
@@ -1,4 +1,4 @@
-#include "MODBUS-LUNA2000.h"
+#include "LUNA2000-MODBUS.h"
 
 void update_modbus_registers_luna2000()
 {

--- a/Software/src/inverter/LUNA2000-MODBUS.h
+++ b/Software/src/inverter/LUNA2000-MODBUS.h
@@ -1,8 +1,8 @@
-#ifndef MODBUS_BYD_H
-#define MODBUS_BYD_H
+#ifndef LUNA2000_MODBUS_H
+#define LUNA2000_MODBUS_H
 #include <Arduino.h>
 
-#define MB_RTU_NUM_VALUES 30000
+#define MB_RTU_NUM_VALUES 50000
 // Definitions for BMS status
 #define STANDBY 0
 #define INACTIVE 1
@@ -31,8 +31,7 @@ extern uint16_t max_power;
 extern uint16_t max_volt_modbus_byd;
 extern uint16_t min_volt_modbus_byd;
 
-void handle_static_data_modbus_byd();
-void handle_update_data_modbusp201_byd();
-void handle_update_data_modbusp301_byd();
-void update_modbus_registers_byd();
+void update_modbus_registers_luna2000();
+void handle_update_data_modbus32051();
+void handle_update_data_modbus39500();
 #endif


### PR DESCRIPTION
This pull request updates the file names and macros for naming consistency, and it orders macros alphabetically.

Consistency and alphabetical ordering allows easier checking if the code is complete.

Some examples of changes that were made:
- macro update: `CAN_BYD` --> `BYD_CAN` (as all other macros first start with the name of the vendor, followed by the protocol)
- file name update: `MODBUS_LUNA2000.cpp` --> `LUNA2000_MODBUS.cpp` (as other filenames start with the name of the vendor, followed by the name of the protocol)

By ordering the macros alphabetically, I found that:
- a notification of which inverter is used in case of `PYLON_CAN` was missing 
- a notification of which battery is used in case of `CHADEMO_BATTERY` was missing

Both these notifications are now added. 
