### PR TITLE
Bugfix/byd can amp

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -24,9 +24,11 @@
 //#define SOLAX_CAN        //Enable this line to emulate a "SolaX Triple Power LFP" over CAN bus
 
 /* Battery settings */
-#define BATTERY_WH_MAX 30000 //Battery size in Wh (Maximum value for most inverters is 60000 [60kWh], you can use larger batteries but do set value over 60000!
+#define BATTERY_WH_MAX 30000 //Battery size in Wh (Maximum value for most inverters is 60000 [60kWh], you can use larger batteries but do not set value over 60000!
 #define MAXPERCENTAGE 800 //80.0% , Max percentage the battery will charge to (App will show 100% once this value is reached)
 #define MINPERCENTAGE 200 //20.0% , Min percentage the battery will discharge to (App will show 0% once this value is reached)
+#define MAXCHARGEAMP 300 //30.0A , BYD CAN specific setting, Max charge speed in Amp (Some inverters needs to be artificially limited)
+#define MAXDISCHARGEAMP 300 //30.0A , BYD CAN specific setting, Max discharge speed in Amp (Some inverters needs to be artificially limited)
 //define INTERLOCK_REQUIRED //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 
 /* Other options */

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -40,14 +40,21 @@ void update_values_can_byd()
   charge_current = ((max_target_charge_power*10)/max_volt_byd_can); //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   charge_current = (charge_current*10); //Value needs a decimal before getting sent to inverter (81.0A)
+  if(charge_current > MAXCHARGEAMP)
+  {
+	  charge_current = MAXCHARGEAMP; //Cap the value to the max allowed Amp. Some inverters cannot handle large values.
+  }
 
   discharge_current = ((max_target_discharge_power*10)/max_volt_byd_can); //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   discharge_current = (discharge_current*10); //Value needs a decimal before getting sent to inverter (81.0A)
+  if(discharge_current > MAXDISCHARGEAMP)
+  {
+	  discharge_current = MAXDISCHARGEAMP; //Cap the value to the max allowed Amp. Some inverters cannot handle large values.
+  }
 
   temperature_average = ((temperature_max + temperature_min)/2);
   
-
   //Map values to CAN messages
   //Maxvoltage (eg 400.0V = 4000 , 16bits long)
   BYD_110.data.u8[0] = (max_volt_byd_can >> 8);

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -134,33 +134,30 @@ void send_can_byd()
     initialDataSent = 1;
   }
 
-  if(bms_status != FAULT)
-  { // Send CAN messages towards inverter if battery is OK
-    // Send 2s CAN Message
-    if (currentMillis - previousMillis2s >= interval2s)
-    {
-      previousMillis2s = currentMillis;
+  // Send 2s CAN Message
+  if (currentMillis - previousMillis2s >= interval2s)
+  {
+    previousMillis2s = currentMillis;
 
-      ESP32Can.CANWriteFrame(&BYD_110);
-    }
-    // Send 10s CAN Message
-    if (currentMillis - previousMillis10s >= interval10s)
-    {
-      previousMillis10s = currentMillis;
+    ESP32Can.CANWriteFrame(&BYD_110);
+  }
+  // Send 10s CAN Message
+  if (currentMillis - previousMillis10s >= interval10s)
+  {
+    previousMillis10s = currentMillis;
 
-      ESP32Can.CANWriteFrame(&BYD_150);
-      ESP32Can.CANWriteFrame(&BYD_1D0);
-      ESP32Can.CANWriteFrame(&BYD_210);
-      //Serial.println("CAN 10s done");
-    }
-    //Send 60s message
-    if (currentMillis - previousMillis60s >= interval60s)
-    { 
-      previousMillis60s = currentMillis;
+    ESP32Can.CANWriteFrame(&BYD_150);
+    ESP32Can.CANWriteFrame(&BYD_1D0);
+    ESP32Can.CANWriteFrame(&BYD_210);
+    //Serial.println("CAN 10s done");
+  }
+  //Send 60s message
+  if (currentMillis - previousMillis60s >= interval60s)
+  { 
+    previousMillis60s = currentMillis;
 
-      ESP32Can.CANWriteFrame(&BYD_190); 
-      //Serial.println("CAN 60s done");
-    }
+    ESP32Can.CANWriteFrame(&BYD_190); 
+    //Serial.println("CAN 60s done");
   }
 }
 


### PR DESCRIPTION
This PR adds a new parameter to the USER_SETTINGS.h file
![bild](https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/assets/26695010/08cb6d76-f384-4eb4-b08b-7a674d012362)

- You can now specify the max charge A and discharge A that will be sent over BYD CAN protocol
- Also removed the blocking of some CAN messages in BYD can when the FAULT state is active. This was not needed.