### PR TITLE
Fix: syntax error for PYLON inverter and function errors for CHADEMO battery

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -199,11 +199,10 @@ void setup() {
   Serial.println("Luna2000 Modbus RTU protocol selected");
 #endif
 #ifdef PYLON_CAN
-  Serial
-      .println("PYLON CAN protocol selected")
+  Serial.println("PYLON CAN protocol selected");
 #endif
 #ifdef SMA_CAN
-          Serial.println("SMA CAN protocol selected");
+  Serial.println("SMA CAN protocol selected");
 #endif
 #ifdef SOFAR_CAN
   Serial.println("SOFAR CAN protocol selected");

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -271,7 +271,7 @@ void handle_can() {  //This section checks if we have a complete CAN message inc
       receive_can_i3_battery(rx_frame);
 #endif
 #ifdef CHADEMO_BATTERY
-      receive_can_chademo(rx_frame);
+      receive_can_chademo_battery(rx_frame);
 #endif
 #ifdef IMIEV_CZERO_ION_BATTERY
       receive_can_imiev_battery(rx_frame);
@@ -389,7 +389,7 @@ void handle_inverter() {
   update_values_i3_battery();  //Map the values to the correct registers
 #endif
 #ifdef CHADEMO_BATTERY
-  update_values_can_chademo();
+  update_values_chademo_battery();
 #endif
 #ifdef IMIEV_CZERO_ION_BATTERY
   update_values_imiev_battery();  //Map the values to the correct registers


### PR DESCRIPTION
In pull requests #80 I made a small mistake, causing the code to not compile anymore for the:
- PYLON inverter

I also found some other mistakes, that were already existing before pull request #80, causing the code to not compile for the:
- CHADEMO battery

This pull request fixes these issues.


**Details on the mistake I made:**

I forgot a `;` at the end of this line:
https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/blob/2575fcc190aa3edaff9c1c727993d5da1f2ac4a8/Software/Software.ino#L203


**Details on the existing issues**
These functions are not declared:
https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/blob/2575fcc190aa3edaff9c1c727993d5da1f2ac4a8/Software/Software.ino#L275

https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/blob/2575fcc190aa3edaff9c1c727993d5da1f2ac4a8/Software/Software.ino#L393

Please see the changes in the "Files changed" tab for the actual fixes.