### PR TITLE
Bugfix/contactor opening for Tesla

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -309,10 +309,6 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
   Serial.print(", ");
   print_int_with_units("Max voltage allowed: ", max_voltage, "V");
   Serial.println("");
-  print_int_with_units("Max charge current: ", max_charge_current, "A");
-  Serial.print(", ");
-  print_int_with_units("Max discharge current: ", max_discharge_current, "A");
-  Serial.println("");
   Serial.print("Cellstats, Max: ");
   Serial.print(cell_max_v);
   Serial.print("mV (cell ");

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -522,7 +522,7 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
     previousMillis30 = currentMillis;
 
     if (bms_status == ACTIVE) {
-      send221still = 10;
+      send221still = 50;
       ESP32Can.CANWriteFrame(&TESLA_221_1);
       ESP32Can.CANWriteFrame(&TESLA_221_2);
     } else {  //bms_status == FAULT


### PR DESCRIPTION
Added the known working delay for sending 221 messages, from pelle_c. Now it should be possible to open contactors in a fault scenario.

Also removed an unused Amp value in USB debug printout, this confused users