### PR TITLE
Update .gitignore to ignore any .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-Software/.vscode/
+# Ignore any .vscode folder
+*.vscode/


### PR DESCRIPTION
This pull request updates the `.gitignore` file to ignore any `.vscode` folder, independent of its location.

Previously only the `.vscode` folder found in the directory `Software/` was ignored.