### PR TITLE
Add SOC% plausibility detection

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -242,7 +242,7 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
   }
 
   //Check if SOC% is plausible
-  if (battery_voltage > (ABSOLUTE_MAX_VOLTAGE - 100)) {
+  if (battery_voltage > (ABSOLUTE_MAX_VOLTAGE - 100)) { // When pack voltage is close to max, and SOC% is still low, raise FAULT
     if (LB_SOC < 650) {
       bms_status = FAULT;
       Serial.println("ERROR: SOC% reported by battery not plausible. Restart battery!");

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -242,7 +242,8 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
   }
 
   //Check if SOC% is plausible
-  if (battery_voltage > (ABSOLUTE_MAX_VOLTAGE - 100)) { // When pack voltage is close to max, and SOC% is still low, raise FAULT
+  if (battery_voltage >
+      (ABSOLUTE_MAX_VOLTAGE - 100)) {  // When pack voltage is close to max, and SOC% is still low, raise FAULT
     if (LB_SOC < 650) {
       bms_status = FAULT;
       Serial.println("ERROR: SOC% reported by battery not plausible. Restart battery!");

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -241,6 +241,14 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
     max_target_discharge_power = 0;
   }
 
+  //Check if SOC% is plausible
+  if (battery_voltage > (ABSOLUTE_MAX_VOLTAGE - 100)) {
+    if (LB_SOC < 650) {
+      bms_status = FAULT;
+      Serial.println("ERROR: SOC% reported by battery not plausible. Restart battery!");
+    }
+  }
+
   if (LB_Full_CHARGE_flag) {  //Battery reports that it is fully charged stop all further charging incase it hasn't already
     max_target_charge_power = 0;
   }


### PR DESCRIPTION
### What
This PR adds plausibility checks for SOC% on Nissan LEAFs batteries. 

### Why
Using a Nissan LEAF battery below 1A for extended periods of times will cause the BMS to not calculate SOC% correctly. This can happen for instance when using a Checkwatt profile. When this happens, the BMS needs to be rebooted.

### How
We check that if the battery voltage is close to max, and the SOC% is low, we raise a FAULT(red LED) to stop charging/discharging. We also send a message on the USB to inform the user what has happened, so they can take action.