### PR TITLE
Tesla: Increase decimal on Amperage value

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -177,7 +177,7 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
 
   battery_voltage = (volts * 10);  //One more decimal needed (370 -> 3700)
 
-  battery_current = amps;  //TODO, this needs verifying if scaling is right
+  battery_current = (amps * 10);  //Increase decimal (13A -> 13.0A)
 
   capacity_Wh = (nominal_full_pack_energy * 100);  //Scale up 75.2kWh -> 75200Wh
   if (capacity_Wh > 60000) {


### PR DESCRIPTION
Noticed by @Newevg , that the scaling on the current reported by Tesla batteries does not contain decimals. This makes the current value used by inverters not match up with reality.

Example, Nissan LEAF pack reports (130) when 13.0A of current is pulled from the battery. The Tesla Model 3 pack report 13 when 13.0A of current is pulled from the battery.

The fix is to multiply the current value with *10 to get the value to match up with the rest of the system