### PR TITLE
New feature: Test fake battery

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -40,6 +40,7 @@ jobs:
           - NISSAN_LEAF_BATTERY
           - RENAULT_ZOE_BATTERY
           - TESLA_MODEL_3_BATTERY
+          - TEST_FAKE_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
 #         - BYD_CAN

--- a/.github/workflows/compile-all-combinations.yml
+++ b/.github/workflows/compile-all-combinations.yml
@@ -43,6 +43,7 @@ jobs:
           - NISSAN_LEAF_BATTERY
           - RENAULT_ZOE_BATTERY
           - TESLA_MODEL_3_BATTERY
+          - TEST_FAKE_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - BYD_CAN

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -79,6 +79,7 @@ uint16_t cell_min_voltage = 3700;  // Stores the minimum cell voltage value in t
 #define YELLOW 1
 #define RED 2
 #define BLUE 3
+#define TEST_ALL_COLORS 10
 
 Adafruit_NeoPixel pixels(1, WS2812_PIN, NEO_GRB + NEO_KHZ800);
 static uint8_t brightness = 0;
@@ -450,6 +451,9 @@ void handle_LED_state() {
       break;
     case RED:
       pixels.setPixelColor(0, pixels.Color(150, 0, 0));  // Red LED full brightness
+      break;
+    case TEST_ALL_COLORS:
+      pixels.setPixelColor(0, pixels.Color(brightness, abs((100 - brightness)), abs((50 - brightness))));  // RGB
       break;
     default:
       break;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -1,4 +1,4 @@
-/* Do not change any code below this line unless you are sure what you are doing */
+/* Do not change any code below this lc:\Git\BYD-Battery-Emulator-For-Gen24\Software\src\battery\NISSAN-LEAF-BATTERY.hine unless you are sure what you are doing */
 /* Only change battery specific settings in "USER_SETTINGS.h" */
 
 #include <Arduino.h>
@@ -75,12 +75,6 @@ uint16_t cell_max_voltage = 3700;  // Stores the highest cell voltage value in t
 uint16_t cell_min_voltage = 3700;  // Stores the minimum cell voltage value in the system
 
 // LED parameters
-#define GREEN 0
-#define YELLOW 1
-#define RED 2
-#define BLUE 3
-#define TEST_ALL_COLORS 10
-
 Adafruit_NeoPixel pixels(1, WS2812_PIN, NEO_GRB + NEO_KHZ800);
 static uint8_t brightness = 0;
 static bool rampUp = true;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -286,6 +286,9 @@ void inform_user_on_battery() {
 #ifdef TESLA_MODEL_3_BATTERY
   Serial.println("Tesla Model 3 battery selected");
 #endif
+#ifdef TEST_FAKE_BATTERY
+  Serial.println("Test mode with fake battery selected");
+#endif
 }
 
 // Functions
@@ -316,6 +319,9 @@ void receive_can() {  // This section checks if we have a complete CAN message i
 #endif
 #ifdef TESLA_MODEL_3_BATTERY
       receive_can_tesla_model_3_battery(rx_frame);
+#endif
+#ifdef TEST_FAKE_BATTERY
+      receive_can_test_battery(rx_frame);
 #endif
       // Inverter
 #ifdef BYD_CAN
@@ -372,6 +378,9 @@ void send_can() {
 #endif
 #ifdef TESLA_MODEL_3_BATTERY
   send_can_tesla_model_3_battery();
+#endif
+#ifdef TEST_FAKE_BATTERY
+  send_can_test_battery();
 #endif
 }
 
@@ -562,6 +571,9 @@ void update_values() {
 #endif
 #ifdef TESLA_MODEL_3_BATTERY
   update_values_tesla_model_3_battery();  // Map the values to the correct registers
+#endif
+#ifdef TEST_FAKE_BATTERY
+  update_values_test_battery();  // Map the fake values to the correct registers
 #endif
   // Inverter
 #ifdef BYD_CAN

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -1,4 +1,4 @@
-/* Do not change any code below this lc:\Git\BYD-Battery-Emulator-For-Gen24\Software\src\battery\NISSAN-LEAF-BATTERY.hine unless you are sure what you are doing */
+/* Do not change any code below this line unless you are sure what you are doing */
 /* Only change battery specific settings in "USER_SETTINGS.h" */
 
 #include <Arduino.h>

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -13,7 +13,7 @@
 //#define NISSAN_LEAF_BATTERY
 //#define RENAULT_ZOE_BATTERY
 //#define TESLA_MODEL_3_BATTERY
-#define TEST_FAKE_BATTERY
+//#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -13,7 +13,7 @@
 //#define NISSAN_LEAF_BATTERY
 //#define RENAULT_ZOE_BATTERY
 //#define TESLA_MODEL_3_BATTERY
-//#define TEST_FAKE_BATTERY
+#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -13,6 +13,7 @@
 //#define NISSAN_LEAF_BATTERY
 //#define RENAULT_ZOE_BATTERY
 //#define TESLA_MODEL_3_BATTERY
+//#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -29,4 +29,7 @@
 #include "TESLA-MODEL-3-BATTERY.h"  //See this file for more Tesla battery settings
 #endif
 
+#ifdef TEST_FAKE_BATTERY
+#include "TEST-FAKE-BATTERY.h"  //See this file for more Fake battery settings
+#endif
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -25,7 +25,7 @@ extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
-extern uint8_t LEDcolor;                       //Enum, 0-10
+extern uint8_t LEDcolor;           //Enum, 0-10
 extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
 
 // Definitions for bms_status

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -2,6 +2,7 @@
 #define NISSAN_LEAF_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for LED defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -25,7 +26,7 @@ extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-extern uint8_t LEDcolor;                       //Enum, 0-2
+extern uint8_t LEDcolor;                       //Enum, 0-10
 // Definitions for bms_status
 #define STANDBY 0
 #define INACTIVE 1
@@ -33,10 +34,6 @@ extern uint8_t LEDcolor;                       //Enum, 0-2
 #define ACTIVE 3
 #define FAULT 4
 #define UPDATING 5
-// LED colors
-#define GREEN 0
-#define YELLOW 1
-#define RED 2
 
 void update_values_leaf_battery();
 void receive_can_leaf_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -2,6 +2,7 @@
 #define TESLA_MODEL_3_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for LED defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -33,10 +34,6 @@ extern uint8_t LEDcolor;
 #define ACTIVE 3
 #define FAULT 4
 #define UPDATING 5
-// LED colors
-#define GREEN 0
-#define YELLOW 1
-#define RED 2
 
 void update_values_tesla_model_3_battery();
 void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -1,0 +1,81 @@
+#include "TEST-FAKE-BATTERY.h"
+#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
+#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+
+/* Do not change code below unless you are sure what you are doing */
+static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
+static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+static unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
+static const int interval10 = 10;            // interval (ms) at which send CAN Messages
+static const int interval100 = 100;          // interval (ms) at which send CAN Messages
+static const int interval10s = 10000;        // interval (ms) at which send CAN Messages
+
+void print_units(char* header, int value, char* units) {
+  Serial.print(header);
+  Serial.print(value);
+  Serial.print(units);
+}
+
+void update_values_test_battery() { /* This function puts fake values onto the parameters sent towards the inverter */
+  bms_status = ACTIVE;              //Always be in Active mode
+
+  LEDcolor = GREEN;
+
+  SOC = 5000;  // 50.00%
+
+  StateOfHealth = 9900;  // 99.00%
+
+  battery_voltage = 3700;  // 370.0V
+
+  battery_current = 0;  // 0 A
+
+  capacity_Wh = 30000;  // 30kWh
+
+  remaining_capacity_Wh = 15000;  // 15kWh
+
+  cell_max_voltage = 3750;
+
+  cell_min_voltage = 3730;
+
+  stat_batt_power = 0;  // 0W
+
+  temperature_min = 50;  // 5.0*C
+
+  temperature_max = 60;  // 6.0*C
+
+  max_target_discharge_power = 5000;  // 5kW
+
+  max_target_charge_power = 5000;  // 5kW
+
+/*Finally print out values to serial if configured to do so*/
+#ifdef DEBUG_VIA_USB
+  Serial.println("FAKE Values going to inverter");
+  print_units("SOH%: ", (StateOfHealth * 0.01), "% ");
+  print_units(", SOC%: ", (SOC * 0.01), "% ");
+  print_units(", Voltage: ", (battery_voltage * 0.1), "V ");
+  print_units(", Max discharge power: ", max_target_discharge_power, "W ");
+  print_units(", Max charge power: ", max_target_charge_power, "W ");
+  print_units(", Max temp: ", (temperature_max * 0.1), "°C ");
+  print_units(", Min temp: ", (temperature_min * 0.1), "°C ");
+  print_units(", Max cell voltage: ", cell_max_voltage, "mV ");
+  print_units(", Min cell voltage: ", cell_min_voltage, "mV ");
+  Serial.println("");
+#endif
+}
+
+void receive_can_test_battery(CAN_frame_t rx_frame) {
+  switch (rx_frame.MsgID) {
+    case 0xABC:
+      break;
+    default:
+      break;
+  }
+}
+void send_can_test_battery() {
+  unsigned long currentMillis = millis();
+  // Send 100ms CAN Message
+  if (currentMillis - previousMillis100 >= interval100) {
+    previousMillis100 = currentMillis;
+    // Put fake messages here incase you want to test sending CAN
+  }
+}

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -19,7 +19,7 @@ void print_units(char* header, int value, char* units) {
 void update_values_test_battery() { /* This function puts fake values onto the parameters sent towards the inverter */
   bms_status = ACTIVE;              //Always be in Active mode
 
-  LEDcolor = GREEN;
+  LEDcolor = TEST_ALL_COLORS;  // Cycle the LED thru all available colors
 
   SOC = 5000;  // 50.00%
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -1,0 +1,46 @@
+#ifndef TEST_FAKE_BATTERY_H
+#define TEST_FAKE_BATTERY_H
+#include <Arduino.h>
+#include "../../USER_SETTINGS.h"
+#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+
+#define ABSOLUTE_MAX_VOLTAGE \
+  4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
+#define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
+
+// These parameters need to be mapped for the inverter
+extern uint16_t SOC;                         //SOC%, 0-100.00 (0-10000)
+extern uint16_t StateOfHealth;               //SOH%, 0-100.00 (0-10000)
+extern uint16_t battery_voltage;             //V+1,  0-500.0 (0-5000)
+extern uint16_t battery_current;             //A+1,  Goes thru convert2unsignedint16 function (5.0A = 50, -5.0A = 65485)
+extern uint16_t capacity_Wh;                 //Wh,   0-60000
+extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
+extern uint16_t max_target_discharge_power;  //W,    0-60000
+extern uint16_t max_target_charge_power;     //W,    0-60000
+extern uint16_t bms_status;                  //Enum, 0-5
+extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
+extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
+extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
+extern uint16_t cell_max_voltage;  //mV,   0-4350
+extern uint16_t cell_min_voltage;  //mV,   0-4350
+extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
+extern uint8_t LEDcolor;                       //Enum, 0-2
+// Definitions for bms_status
+#define STANDBY 0
+#define INACTIVE 1
+#define DARKSTART 2
+#define ACTIVE 3
+#define FAULT 4
+#define UPDATING 5
+// LED colors
+#define GREEN 0
+#define YELLOW 1
+#define RED 2
+#define BLUE 3
+
+void update_values_test_battery();
+void receive_can_test_battery(CAN_frame_t rx_frame);
+void send_can_test_battery();
+
+#endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -25,8 +25,8 @@ extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
-extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-extern uint8_t LEDcolor;                       //Enum, 0-10
+extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
+extern uint8_t LEDcolor;                    //Enum, 0-10
 // Definitions for bms_status
 #define STANDBY 0
 #define INACTIVE 1

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -38,6 +38,7 @@ extern uint8_t LEDcolor;                       //Enum, 0-2
 #define YELLOW 1
 #define RED 2
 #define BLUE 3
+#define TEST_ALL_COLORS 10
 
 void update_values_test_battery();
 void receive_can_test_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -2,6 +2,7 @@
 #define TEST_FAKE_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for LED defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -25,7 +26,7 @@ extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-extern uint8_t LEDcolor;                       //Enum, 0-2
+extern uint8_t LEDcolor;                       //Enum, 0-10
 // Definitions for bms_status
 #define STANDBY 0
 #define INACTIVE 1
@@ -33,12 +34,6 @@ extern uint8_t LEDcolor;                       //Enum, 0-2
 #define ACTIVE 3
 #define FAULT 4
 #define UPDATING 5
-// LED colors
-#define GREEN 0
-#define YELLOW 1
-#define RED 2
-#define BLUE 3
-#define TEST_ALL_COLORS 10
 
 void update_values_test_battery();
 void receive_can_test_battery(CAN_frame_t rx_frame);

--- a/Software/src/devboard/config.h
+++ b/Software/src/devboard/config.h
@@ -32,4 +32,11 @@
 #define SD_CS_PIN 13
 #define WS2812_PIN 4
 
+// LED definitions for the board
+#define GREEN 0
+#define YELLOW 1
+#define RED 2
+#define BLUE 3
+#define TEST_ALL_COLORS 10
+
 #endif

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -21,7 +21,7 @@ extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern uint16_t min_voltage;
 extern uint16_t max_voltage;
-extern uint8_t LEDcolor;  //Enum, 0-2
+extern uint8_t LEDcolor;  //Enum, 0-10
 // Definitions for BMS status
 #define STANDBY 0
 #define INACTIVE 1

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -20,7 +20,7 @@ extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
-extern uint8_t LEDcolor;                       //Enum, 0-10
+extern uint8_t LEDcolor;           //Enum, 0-10
 extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
 
 extern uint16_t min_voltage;

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -21,7 +21,7 @@ extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-extern uint8_t LEDcolor;                       //Enum, 0-2
+extern uint8_t LEDcolor;                       //Enum, 0-10
 extern uint16_t min_voltage;
 extern uint16_t max_voltage;
 // Definitions for BMS status


### PR DESCRIPTION
### What
This pull request adds a new feature, which lets you test your system with a fake battery!

### Why
This new test mode can be very useful when testing a new inverter, or testing the inverter before the battery setup is complete, or doing isolation testing for troubleshooting. This means you no longer have to have a working battery on the CAN bus. The user "f1racr" on the Discord had great progress with this test mode!

### How
There is now a new define, `#define TEST_FAKE_BATTERY` that can be enabled in the `USER_SETTINGS.h` file. When enabled, the values set in `TEST-FAKE-BATTERY.cpp` will be sent towards your inverter of choice. While in this test mode, the LED on the board will cycle thru all RGB values, letting you know you are in a special mode.