### PR TITLE
Use booleans for booleans

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -106,8 +106,8 @@ unsigned long prechargeStartTime = 0;
 unsigned long negativeStartTime = 0;
 unsigned long timeSpentInFaultedMode = 0;
 #endif
-uint8_t batteryAllowsContactorClosing = 0;
-uint8_t inverterAllowsContactorClosing = 1;
+uint8_t batteryAllowsContactorClosing = false;
+uint8_t inverterAllowsContactorClosing = true;
 
 // Initialization
 void setup() {
@@ -261,8 +261,8 @@ void inform_user_on_inverter() {
   Serial.println("SOFAR CAN protocol selected");
 #endif
 #ifdef SOLAX_CAN
-  inverterAllowsContactorClosing = 0;  // The inverter needs to allow first on this protocol
-  intervalUpdateValues = 800;          // This protocol also requires the values to be updated faster
+  inverterAllowsContactorClosing = false;  // The inverter needs to allow first on this protocol
+  intervalUpdateValues = 800;              // This protocol also requires the values to be updated faster
   Serial.println("SOLAX CAN protocol selected");
 #endif
 }

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -106,8 +106,8 @@ unsigned long prechargeStartTime = 0;
 unsigned long negativeStartTime = 0;
 unsigned long timeSpentInFaultedMode = 0;
 #endif
-uint8_t batteryAllowsContactorClosing = false;
-uint8_t inverterAllowsContactorClosing = true;
+bool batteryAllowsContactorClosing = false;
+bool inverterAllowsContactorClosing = true;
 
 // Initialization
 void setup() {

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -23,7 +23,7 @@ extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
-extern uint8_t batteryAllowsContactorClosing;
+extern bool batteryAllowsContactorClosing;
 // Definitions for BMS status
 #define STANDBY 0
 #define INACTIVE 1

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -25,7 +25,7 @@ extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern uint16_t cell_max_voltage;
 extern uint16_t cell_min_voltage;
-extern uint8_t batteryAllowsContactorClosing;
+extern bool batteryAllowsContactorClosing;
 extern uint8_t LEDcolor;
 // Definitions for BMS status
 #define STANDBY 0

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -23,7 +23,7 @@ extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
-extern uint8_t batteryAllowsContactorClosing;
+extern bool batteryAllowsContactorClosing;
 // Definitions for BMS status
 #define STANDBY 0
 #define INACTIVE 1

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -405,9 +405,9 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame) {
       LB_Failsafe_Status = (rx_frame.data.u8[1] & 0x07);
       LB_MainRelayOn_flag = (byte)((rx_frame.data.u8[3] & 0x20) >> 5);
       if (LB_MainRelayOn_flag) {
-        batteryAllowsContactorClosing = 1;
+        batteryAllowsContactorClosing = true;
       } else {
-        batteryAllowsContactorClosing = 0;
+        batteryAllowsContactorClosing = false;
       }
       LB_Full_CHARGE_flag = (byte)((rx_frame.data.u8[3] & 0x10) >> 4);
       LB_Interlock = (byte)((rx_frame.data.u8[3] & 0x08) >> 3);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -24,8 +24,8 @@ extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
-extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-extern uint8_t LEDcolor;                       //Enum, 0-2
+extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
+extern uint8_t LEDcolor;                    //Enum, 0-2
 // Definitions for bms_status
 #define STANDBY 0
 #define INACTIVE 1

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -71,7 +71,7 @@ static uint8_t packContactorSetState = 0;
 static uint8_t packCtrsClosingAllowed = 0;
 static uint8_t pyroTestInProgress = 0;
 static uint8_t send221still = 10;
-static uint8_t LFP_Chemistry = false;
+static bool LFP_Chemistry = false;
 //Fault codes
 static uint8_t WatchdogReset = 0;           //Warns if the processor has experienced a reset due to watchdog reset.
 static uint8_t PowerLossReset = 0;          //Warns if the processor has experienced a reset due to power loss.

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -71,7 +71,7 @@ static uint8_t packContactorSetState = 0;
 static uint8_t packCtrsClosingAllowed = 0;
 static uint8_t pyroTestInProgress = 0;
 static uint8_t send221still = 10;
-static uint8_t LFP_Chemistry = 0;
+static uint8_t LFP_Chemistry = false;
 //Fault codes
 static uint8_t WatchdogReset = 0;           //Warns if the processor has experienced a reset due to watchdog reset.
 static uint8_t PowerLossReset = 0;          //Warns if the processor has experienced a reset due to power loss.
@@ -235,10 +235,10 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
   //Determine which chemistry battery pack is using (crude method, TODO: replace with real CAN data later)
   if (soc_vi > 900) {  //When SOC% is over 90.0%, we can use max cell voltage to estimate what chemistry is used
     if (cell_max_v < 3450) {
-      LFP_Chemistry = 1;
+      LFP_Chemistry = true;
     }
     if (cell_max_v > 3700) {
-      LFP_Chemistry = 0;
+      LFP_Chemistry = false;
     }
   }
 

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -20,8 +20,8 @@ extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
-extern uint8_t batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-extern uint8_t LEDcolor;                       //Enum, 0-2
+extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
+extern uint8_t LEDcolor;                    //Enum, 0-2
 extern uint16_t min_voltage;
 extern uint16_t max_voltage;
 // Definitions for BMS status

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -118,7 +118,7 @@ void CAN_WriteFrame(CAN_frame_t* tx_frame) {
 void update_values_can_solax() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   // If not receiveing any communication from the inverter, open contactors and return to battery announce state
   if (millis() - LastFrameTime >= SolaxTimeout) {
-    inverterAllowsContactorClosing = 0;
+    inverterAllowsContactorClosing = false;
     STATE = BATTERY_ANNOUNCE;
   }
   //Calculate the required values
@@ -220,7 +220,7 @@ void receive_can_solax(CAN_frame_t rx_frame) {
     switch (STATE) {
       case (BATTERY_ANNOUNCE):
         Serial.println("Solax Battery State: Announce");
-        inverterAllowsContactorClosing = 0;
+        inverterAllowsContactorClosing = false;
         SOLAX_1875.data.u8[4] = (0x00);  // Inform Inverter: Contactor 0=off, 1=on.
         for (int i = 0; i <= number_of_batteries; i++) {
           CAN_WriteFrame(&SOLAX_1872);
@@ -253,7 +253,7 @@ void receive_can_solax(CAN_frame_t rx_frame) {
         break;
 
       case (CONTACTOR_CLOSED):
-        inverterAllowsContactorClosing = 1;
+        inverterAllowsContactorClosing = true;
         SOLAX_1875.data.u8[4] = (0x01);  // Inform Inverter: Contactor 0=off, 1=on.
         CAN_WriteFrame(&SOLAX_1872);
         CAN_WriteFrame(&SOLAX_1873);

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -26,7 +26,7 @@ extern uint16_t min_voltage;
 extern uint16_t max_voltage;
 extern uint16_t cell_max_voltage;
 extern uint16_t cell_min_voltage;
-extern uint8_t inverterAllowsContactorClosing;
+extern bool inverterAllowsContactorClosing;
 
 // Timeout in milliseconds
 #define SolaxTimeout 2000


### PR DESCRIPTION
## What
This pull request updates boolean parameters to use booleans (true, false), rather than (1, 0).

## Why
Booleans are easier to read and understand by humans than 1, 0, and the usage of them lead to less errors in the code.