### PR TITLE
Add ramped charge value for Tesla

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -156,7 +156,7 @@ static const char* hvilStatusState[] = {"NOT OK",
 #define MIN_CELL_VOLTAGE_NCA_NCM 2950   //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_NCA_NCM 500  //LED turns yellow on the board if mv delta exceeds this value
 
-#define MAX_CELL_VOLTAGE_LFP 3450   //Battery is put into emergency stop if one cell goes over this value
+#define MAX_CELL_VOLTAGE_LFP 3500   //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_LFP 2800   //Battery is put into emergency stop if one cell goes over this value
 #define MAX_CELL_DEVIATION_LFP 150  //LED turns yellow on the board if mv delta exceeds this value
 

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -196,9 +196,11 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
 
   //The allowed charge power behaves strangely. We instead estimate this value
   if (SOC == 10000) {
-    max_target_charge_power = 0;  //When battery is 100% full, set allowed charge W to 0
-  } else {
-    max_target_charge_power = 15000;  //Otherwise we can push 15kW into the pack!
+    max_target_charge_power = 0;            // When battery is 100% full, set allowed charge W to 0
+  } else if (SOC >= 9500 && SOC <= 9999) {  // When battery is between 95-99.99%, ramp the value between Max<->0
+    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (SOC - 9500) / 500);
+  } else {  // Outside the specified SOC range, set the charge power to the maximum
+    max_target_charge_power = MAXCHARGEPOWERALLOWED;
   }
 
   stat_batt_power = (volts * amps);  //TODO: check if scaling is OK

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -193,6 +193,9 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
   } else {
     max_target_discharge_power = temporaryvariable;
   }
+  if (SOC < 20) {  // When battery is lower than 0.20% , set allowed discharge W to 0
+    max_target_discharge_power = 0;
+  }
 
   //The allowed charge power behaves strangely. We instead estimate this value
   max_target_charge_power = MAXCHARGEPOWERALLOWED;

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -196,8 +196,8 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
 
   //The allowed charge power behaves strangely. We instead estimate this value
   if (SOC == 10000) {
-    max_target_charge_power = 0;            // When battery is 100% full, set allowed charge W to 0
-  } else if (SOC >= 9500 && SOC <= 9999) {  // When battery is between 95-99.99%, ramp the value between Max<->0
+    max_target_charge_power = 0;  // When battery is 100% full, set allowed charge W to 0
+  } else if (SOC > 9500) {        // When battery is between 95-99.99%, ramp the value between Max<->0
     max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (SOC - 9500) / 500);
   } else {  // Outside the specified SOC range, set the charge power to the maximum
     max_target_charge_power = MAXCHARGEPOWERALLOWED;

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -26,7 +26,6 @@ CAN_frame_t TESLA_221_2 = {
     .MsgID = 0x221,
     .data = {0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA}};  //Contactor Frame 221 - hv_up_for_drive
 
-static uint32_t temporaryvariable = 0;
 static uint32_t total_discharge = 0;
 static uint32_t total_charge = 0;
 static uint16_t volts = 0;     // V
@@ -186,15 +185,13 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
 
   remaining_capacity_Wh = (expected_energy_remaining * 100);  //Scale up 60.3kWh -> 60300Wh
 
-  //Calculate the allowed discharge power, cap it if it gets too large
-  temporaryvariable = (max_discharge_current * volts);
-  if (temporaryvariable > 60000) {
-    max_target_discharge_power = 60000;
-  } else {
-    max_target_discharge_power = temporaryvariable;
-  }
-  if (SOC < 20) {  // When battery is lower than 0.20% , set allowed discharge W to 0
+  // Define the allowed discharge power
+  max_target_discharge_power = (max_discharge_current * volts);
+  // Cap the allowed discharge power if battery is empty, or discharge power is higher than the maximum discharge power allowed
+  if (SOC == 0) {
     max_target_discharge_power = 0;
+  } else if (max_target_discharge_power > MAXDISCHARGEPOWERALLOWED) {
+    max_target_discharge_power = MAXDISCHARGEPOWERALLOWED;
   }
 
   //The allowed charge power behaves strangely. We instead estimate this value
@@ -202,7 +199,7 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
     max_target_charge_power = 0;
   } else if (soc_vi > 950) {  // When real SOC is between 95-99.99%, ramp the value between Max<->0
     max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - 950) / 50.0);
-  } else { // No limits, max charging power allowed
+  } else {  // No limits, max charging power allowed
     max_target_charge_power = MAXCHARGEPOWERALLOWED;
   }
 

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -157,7 +157,7 @@ static const char* hvilStatusState[] = {"NOT OK",
 #define MAX_CELL_DEVIATION_NCA_NCM 500  //LED turns yellow on the board if mv delta exceeds this value
 
 #define MAX_CELL_VOLTAGE_LFP 3500   //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_LFP 2800   //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_LFP 2800   //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_LFP 150  //LED turns yellow on the board if mv delta exceeds this value
 
 void update_values_tesla_model_3_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
@@ -195,12 +195,12 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
   }
 
   //The allowed charge power behaves strangely. We instead estimate this value
-  if (SOC == 10000) {
-    max_target_charge_power = 0;  // When battery is 100% full, set allowed charge W to 0
-  } else if (SOC > 9500) {        // When battery is between 95-99.99%, ramp the value between Max<->0
-    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (SOC - 9500) / 500.0);
-  } else {  // Outside the specified SOC range, set the charge power to the maximum
-    max_target_charge_power = MAXCHARGEPOWERALLOWED;
+  max_target_charge_power = MAXCHARGEPOWERALLOWED;
+  if (soc_vi > 950) {  // When battery is between 95-99.99% real SOC, ramp the value between Max<->0
+    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - 950) / 50.0);
+  }
+  if (SOC == 10000) {  // When battery is defined as 100% full, set allowed charge W to 0
+    max_target_charge_power = 0;
   }
 
   stat_batt_power = (volts * amps);  //TODO: check if scaling is OK

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -198,7 +198,7 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
   if (SOC == 10000) {
     max_target_charge_power = 0;  // When battery is 100% full, set allowed charge W to 0
   } else if (SOC > 9500) {        // When battery is between 95-99.99%, ramp the value between Max<->0
-    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (SOC - 9500) / 500);
+    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (SOC - 9500) / 500.0);
   } else {  // Outside the specified SOC range, set the charge power to the maximum
     max_target_charge_power = MAXCHARGEPOWERALLOWED;
   }

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -198,12 +198,12 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
   }
 
   //The allowed charge power behaves strangely. We instead estimate this value
-  max_target_charge_power = MAXCHARGEPOWERALLOWED;
-  if (soc_vi > 950) {  // When battery is between 95-99.99% real SOC, ramp the value between Max<->0
-    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - 950) / 50.0);
-  }
-  if (SOC == 10000) {  // When battery is defined as 100% full, set allowed charge W to 0
+  if (SOC == 10000) {  // When scaled SOC is 100%, set allowed charge power to 0
     max_target_charge_power = 0;
+  } else if (soc_vi > 950) {  // When real SOC is between 95-99.99%, ramp the value between Max<->0
+    max_target_charge_power = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - 950) / 50.0);
+  } else { // No limits, max charging power allowed
+    max_target_charge_power = MAXCHARGEPOWERALLOWED;
   }
 
   stat_batt_power = (volts * amps);  //TODO: check if scaling is OK

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -9,6 +9,8 @@
   4030  // 403.0V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 2450    // 245.0V if battery voltage goes under this, discharging further is disabled
 #define MAXCHARGEPOWERALLOWED 15000  // 15000W we use a define since the value supplied by Tesla is always 0
+#define MAXDISCHARGEPOWERALLOWED \
+  60000  // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise
 
 // These parameters need to be mapped for the Inverter
 extern uint16_t SOC;

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -7,7 +7,8 @@
 
 #define ABSOLUTE_MAX_VOLTAGE \
   4030  // 403.0V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
-#define ABSOLUTE_MIN_VOLTAGE 2450  // 245.0V if battery voltage goes under this, discharging further is disabled
+#define ABSOLUTE_MIN_VOLTAGE 2450    // 245.0V if battery voltage goes under this, discharging further is disabled
+#define MAXCHARGEPOWERALLOWED 15000  // 15000W we use a define since the value supplied by Tesla is always 0
 
 // These parameters need to be mapped for the Inverter
 extern uint16_t SOC;


### PR DESCRIPTION
### What
This PR adds a new feature for Tesla batteries, smoothing of charge max value for when battery approaches 100%

### Why
@Newevg noticed that when trying to charge their LFP Tesla battery to 100%, charging it with 15kW all the way up to 100% was not possible. To reach 100%, the charge needs to taper off, otherwise the contactors would open, and the BMS would flag a fault. 

### How
The .header file now has a configurable max value, `MAXCHARGEPOWERALLOWED`. This value, which defaults to 15000W, will be used when battery is between 0-95%. When battery reaches 95%, it ramps between `MAXCHARGEPOWERALLOWED`-> 0 in the 95-100% range. This should allow the battery to more gracefully reach 100%.