### PR TITLE
Add compilation error for missing battery

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -288,6 +288,9 @@ void inform_user_on_battery() {
 #ifdef TEST_FAKE_BATTERY
   Serial.println("Test mode with fake battery selected");
 #endif
+#if !defined(ABSOLUTE_MAX_VOLTAGE)
+#error No battery selected! Choose one from the USER_SETTINGS.h file
+#endif
 }
 
 // Functions


### PR DESCRIPTION
### What
This PR adds a compiler error, incase the user forgets to define a battery. This makes the project easier for beginners.

### Why
The USER_SETTINGS.h file is blank when a new user starts. If nothing is defined and you try to compile, the current compiler error doesn't really make sense:
![bild](https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/assets/26695010/016737a3-d49b-4aff-8aa6-ddaec8f510f0)

### How
A compiler #error is used to guide the user to the correct place, so a battery can be defined
![bild](https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/assets/26695010/9224bcc5-0008-42e4-b709-a763dbb535cb)
