### PR TITLE
BYD Modbus: Add freezing temperature overwriting

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -2,6 +2,7 @@
 
 void update_modbus_registers_byd() {
   //Updata for ModbusRTU Server for BYD
+  verify_temperature_modbus();
   handle_update_data_modbusp201_byd();
   handle_update_data_modbusp301_byd();
 }
@@ -105,4 +106,21 @@ void handle_update_data_modbusp301_byd() {
   battery_data[23] = StateOfHealth;  // Id.: p324 Value.: 9900 Scaled value.: 99% Comment.: SOH
   static uint16_t i = 300;
   memcpy(&mbPV[i], battery_data, sizeof(battery_data));
+}
+
+void verify_temperature_modbus() {
+  // This section checks if the battery temperature is negative, and incase it falls between -9.0 and -20.0C degrees
+  // The Fronius Gen24 (and other Fronius inverters also affected), will stop charge/discharge if the battery gets colder than -10°C.
+  // This is due to the original battery pack (BYD HVM), is a lithium iron phosphate battery, that cannot be charged in cold weather.
+  // When using EV packs with NCM/LMO/NCA chemsitry, this is not a problem, since these chemistries are OK for outdoor cold use.
+  if (temperature_min > 32768) {                               // Signed value on negative side
+    if (temperature_min < 65445 && temperature_min > 65335) {  // Between -9.0 and -20.0C degrees
+      temperature_min = 65445;                                 //Cap value to -9.0C
+    }
+  }
+  if (temperature_max > 32768) {                               // Signed value on negative side
+    if (temperature_max < 65445 && temperature_max > 65335) {  // Between -9.0 and -20.0C degrees
+      temperature_max = 65445;                                 //Cap value to -9.0C
+    }
+  }
 }

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -31,6 +31,7 @@ extern uint16_t max_voltage;
 extern uint16_t min_voltage;
 
 void handle_static_data_modbus_byd();
+void verify_temperature_modbus();
 void handle_update_data_modbusp201_byd();
 void handle_update_data_modbusp301_byd();
 void update_modbus_registers_byd();


### PR DESCRIPTION
### What
This PR adds temperature checks for BYD Modbus protocol. Incase we are getting too cold, we fake the temperature value for a while

### Why
The Fronius Gen24 (and other Fronius inverters also affected), will stop charge/discharge if the battery gets colder than -10°C. This is due to the original battery pack (BYD HVM), is a lithium iron phosphate battery, that cannot be charged in cold weather. When using NCM/LMO/NCA batteries, this is not a problem, since these chemistries are OK for outdoor cold use. #111

### How
Incase the real temperature is between -9.0 and -20.0C degrees, we fake the value to -9.0C during this value range. When the battery goes below -20.0C , the real value is again forwarded. By doing this we gain an additional 10 degrees of operating range.