### PR TITLE
Tesla: Remove misleading min/max printout

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -306,7 +306,7 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
     Serial.print("YES, ");
   else
     Serial.print("NO, ");
-  if(LFP_Chemistry){
+  if (LFP_Chemistry) {
     Serial.print("LFP chemistry detected!");
   }
   Serial.println("");

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -306,9 +306,9 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
     Serial.print("YES, ");
   else
     Serial.print("NO, ");
-  print_int_with_units("Min voltage allowed: ", min_voltage, "V");
-  Serial.print(", ");
-  print_int_with_units("Max voltage allowed: ", max_voltage, "V");
+  if(LFP_Chemistry){
+    Serial.print("LFP chemistry detected!");
+  }
   Serial.println("");
   Serial.print("Cellstats, Max: ");
   Serial.print(cell_max_v);


### PR DESCRIPTION
### What?
This PR makes the debug printout for Tesla batteries easier for beginners

### Why?
There were many questions about the min / max voltages reported via CAN by Tesla, especially for LFP packs. The values were outright wrong, stating that the LFP packs could go to 402V 🙈 

### How?
Instead of printing the misleading min/max, we instead print `LFP chemistry detected!` if we notice that an LFP pack is used. This is much more useful info to have.