### PR TITLE
Tesla: Fix power W calculation

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -203,7 +203,7 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
     max_target_charge_power = MAXCHARGEPOWERALLOWED;
   }
 
-  power = (volts * amps);
+  power = ((volts / 10) * amps);
   stat_batt_power = convert2unsignedInt16(power);
 
   min_temp = (min_temp * 10);

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -30,6 +30,7 @@ static uint32_t total_discharge = 0;
 static uint32_t total_charge = 0;
 static uint16_t volts = 0;     // V
 static int16_t amps = 0;       // A
+static int16_t power = 0;      // W
 static uint16_t raw_amps = 0;  // A
 static int16_t max_temp = 6;   // C*
 static int16_t min_temp = 5;   // C*
@@ -202,7 +203,8 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
     max_target_charge_power = MAXCHARGEPOWERALLOWED;
   }
 
-  stat_batt_power = (volts * amps);  //TODO: check if scaling is OK
+  power = (volts * amps);
+  stat_batt_power = convert2unsignedInt16(power);
 
   min_temp = (min_temp * 10);
   temperature_min = convert2unsignedInt16(min_temp);


### PR DESCRIPTION
### What
Noticed by @MarkoBolt that the stat_bat_power variable is not formatted correctly. This affects all inverters getting wrong values, and also the webserver will show wrong values.

### Why
See how the W is shows as -21313W instead of −8685W
![bild](https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/assets/26695010/b13c3585-971b-45b3-aba1-736afbcc18d9)

After the fix is applied:
![bild](https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/assets/26695010/b254e721-ea3f-4b40-b113-62efcf137723)


### How
This PR fixes the calculation of the value. It is tricky since the signed16 value should be put in an unsigned register (due to legacy modbus reasons)