### PR TITLE
Tesla S/3/X/Y: Fix Wh max/remain values

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -243,6 +243,15 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
     }
   }
 
+  //Check if SOC% is plausible
+  if (battery_voltage >
+      (ABSOLUTE_MAX_VOLTAGE - 100)) {  // When pack voltage is close to max, and SOC% is still low, raise FAULT
+    if (SOC < 6500) {                  //When SOC is less than 65.00% when approaching max voltage
+      bms_status = FAULT;
+      Serial.println("ERROR: SOC% reported by battery not plausible. Restart battery!");
+    }
+  }
+
   if (LFP_Chemistry) {  //LFP limits used for voltage safeties
     if (cell_max_v >= MAX_CELL_VOLTAGE_LFP) {
       bms_status = FAULT;
@@ -269,6 +278,11 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
       LEDcolor = YELLOW;
       Serial.println("ERROR: HIGH CELL DEVIATION!!! Inspect battery!");
     }
+  }
+
+  if (bms_status == FAULT) {  //Incase we enter a critical fault state, zero out the allowed limits
+    max_target_charge_power = 0;
+    max_target_discharge_power = 0;
   }
 
   /* Safeties verified. Perform USB serial printout if configured to do so */

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -178,12 +178,10 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
 
   battery_current = convert2unsignedInt16(amps);  //13.0A
 
-  capacity_Wh = (nominal_full_pack_energy * 100);  //Scale up 75.2kWh -> 75200Wh
-  if (capacity_Wh > 60000) {
-    capacity_Wh = 60000;
-  }
+  capacity_Wh = BATTERY_WH_MAX;  //Use the configured value to avoid overflows
 
-  remaining_capacity_Wh = (expected_energy_remaining * 100);  //Scale up 60.3kWh -> 60300Wh
+  //Calculate the remaining Wh amount from SOC% and max Wh value.
+  remaining_capacity_Wh = remaining_capacity_Wh = static_cast<int>((static_cast<double>(SOC) / 10000) * BATTERY_WH_MAX);
 
   // Define the allowed discharge power
   max_target_discharge_power = (max_discharge_current * volts);


### PR DESCRIPTION
### What
This PR fixes the WH max and WH remaining value sent towards inverter. It also adds SOC% plausibility detection, same as LEAF has.

### Why
Noticed by f1racer, the Wh value max would sometimes display as 0, and the remaining value would be incorrect. This would mess up Webserver info, along with sending incorrect info towards inverters.
![bild](https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/assets/26695010/080592a3-fc67-4104-8d83-0f91ce73fe8f)


### How
We now use the configured WH number to avoid any u16 overflows. The WH number set in `USER_SETTINGS.h` can be between 0-65000Wh