### PR TITLE
Add way to disable AP

### DIFF
--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -1,6 +1,7 @@
 #include "USER_SETTINGS.h"
 
 #ifdef WEBSERVER
+#define ENABLE_AP                                     //Comment out this line to turn off the broadcasted AP
 const char* ssid = "REPLACE_WITH_YOUR_SSID";          // maximum of 63 characters;
 const char* password = "REPLACE_WITH_YOUR_PASSWORD";  // minimum of 8 characters;
 const char* ssidAP = "Battery Emulator";              // maximum of 63 characters;

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -44,6 +44,6 @@
 //#define DUAL_CAN              //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for FoxESS inverters)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
-//#define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver
+//#define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
 
 #endif

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -42,10 +42,15 @@ unsigned long wifi_connect_current_time;
 const long wifi_connect_timeout = 5000;  // Timeout for WiFi connect in milliseconds
 
 void init_webserver() {
-  // Configure WiFi
-  WiFi.mode(WIFI_AP_STA);  // Simultaneous WiFi Access Point and WiFi STAtion
+// Configure WiFi
+#ifdef ENABLE_AP
+  WiFi.mode(WIFI_AP_STA);  // Simultaneous WiFi AP and Router connection
   init_WiFi_AP();
   init_WiFi_STA(ssid, password);
+#else
+  WiFi.mode(WIFI_STA);  // Only Router connection
+  init_WiFi_STA(ssid, password);
+#endif
 
   // Route for root / web page
   server.on("/", HTTP_GET,


### PR DESCRIPTION
### What
This PR adds the ability to disable the Access Point Wifi broadcasting. 📶❌

### Why
Due to cybersecurity reasons, broadcasting an AP might not always be desired

### How
The `USER_SETTINGS.cpp` file now contains a row that controls wheter the AP should be enabled or not

`#define ENABLE_AP //Comment out this line to turn off the broadcasted AP`

This row can be commented out incase you want to disable AP