### PR TITLE
Bugfix: OTA not communicated to inverter/user

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -321,12 +321,12 @@ void onOTAStart() {
 }
 
 void onOTAProgress(size_t current, size_t final) {
+  bms_status = 5;  //Inform inverter that we are updating
+  LEDcolor = BLUE;
   // Log every 1 second
   if (millis() - ota_progress_millis > 1000) {
     ota_progress_millis = millis();
     Serial.printf("OTA Progress Current: %u bytes, Final: %u bytes\n", current, final);
-    bms_status = 5;  //Inform inverter that we are updating
-    LEDcolor = BLUE;
   }
 }
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -316,7 +316,8 @@ String processor(const String& var) {
 void onOTAStart() {
   // Log when OTA has started
   Serial.println("OTA update started!");
-  // <Add your own code here>
+  bms_status = 5;  //Inform inverter that we are updating
+  LEDcolor = BLUE;
 }
 
 void onOTAProgress(size_t current, size_t final) {
@@ -324,6 +325,8 @@ void onOTAProgress(size_t current, size_t final) {
   if (millis() - ota_progress_millis > 1000) {
     ota_progress_millis = millis();
     Serial.printf("OTA Progress Current: %u bytes, Final: %u bytes\n", current, final);
+    bms_status = 5;  //Inform inverter that we are updating
+    LEDcolor = BLUE;
   }
 }
 
@@ -334,5 +337,6 @@ void onOTAEnd(bool success) {
   } else {
     Serial.println("There was an error during OTA update!");
   }
-  // <Add your own code here>
+  bms_status = 5;  //Inform inverter that we are updating
+  LEDcolor = BLUE;
 }


### PR DESCRIPTION
### What
This PR adds handling for inverter, so that the inverter knows that BMS is updating. It also sets the LED on the board to blue color while the update is running

### Why
So the inverter can act properly while OTA is happening

### How
The LEDcolor variable is set to blue, and the bms_status is set to UPDATING while OTA is running