### PR TITLE
Bugfix: Charge/Discharge status bits (+refactoring)

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -48,35 +48,24 @@ uint16_t mbPV[MB_RTU_NUM_VALUES];  // Process variable memory
 ModbusServerRTU MBserver(Serial2, 2000);
 #endif
 
-// Inverter parameters
-// Inverter states
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
-// Common inverter parameters
-uint16_t capacity_Wh_startup = BATTERY_WH_MAX;
-uint16_t max_power = 40960;                   // 41kW
+// Common inverter parameters. Batteries map their values to these variables
 uint16_t max_voltage = ABSOLUTE_MAX_VOLTAGE;  // If higher charging is not possible (goes into forced discharge)
-uint16_t min_voltage = ABSOLUTE_MIN_VOLTAGE;  // If lower Gen24 disables battery
-uint16_t battery_voltage = 3700;
+uint16_t min_voltage = ABSOLUTE_MIN_VOLTAGE;  // If lower disables discharging battery
+uint16_t battery_voltage = 3700;              //V+1,  0-500.0 (0-5000)
 uint16_t battery_current = 0;
-uint16_t SOC = 5000;                              // SOC 0-100.00% // Updates later on from CAN
-uint16_t StateOfHealth = 9900;                    // SOH 0-100.00% // Updates later on from CAN
-uint16_t capacity_Wh = BATTERY_WH_MAX;            // Updates later on from CAN
-uint16_t remaining_capacity_Wh = BATTERY_WH_MAX;  // Updates later on from CAN
-uint16_t max_target_discharge_power = 0;          // 0W (0W > restricts to no discharge) // Updates later on from CAN
-uint16_t max_target_charge_power =
-    4312;  // 4.3kW (during charge), both 307&308 can be set (>0) at the same time // Updates later on from CAN. Max value is 30000W
-uint16_t temperature_max = 50;     // Reads from battery later
-uint16_t temperature_min = 60;     // Reads from battery later
-uint16_t bms_char_dis_status;      // 0 idle, 1 discharging, 2, charging
-uint16_t bms_status = ACTIVE;      // ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
-uint16_t stat_batt_power = 0;      // Power going in/out of battery
-uint16_t cell_max_voltage = 3700;  // Stores the highest cell voltage value in the system
-uint16_t cell_min_voltage = 3700;  // Stores the minimum cell voltage value in the system
+uint16_t SOC = 5000;                              //SOC%, 0-100.00 (0-10000)
+uint16_t StateOfHealth = 9900;                    //SOH%, 0-100.00 (0-10000)
+uint16_t capacity_Wh = BATTERY_WH_MAX;            //Wh,   0-60000
+uint16_t remaining_capacity_Wh = BATTERY_WH_MAX;  //Wh,   0-60000
+uint16_t max_target_discharge_power = 0;          // 0W (0W > restricts to no discharge), Updates later on from CAN
+uint16_t max_target_charge_power = 4312;          // Init to 4.3kW, Updates later on from CAN
+uint16_t temperature_max = 50;          //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
+uint16_t temperature_min = 60;          // Reads from battery later
+uint8_t bms_char_dis_status = STANDBY;  // 0 standby, 1 discharging, 2, charging
+uint8_t bms_status = ACTIVE;            // ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
+uint16_t stat_batt_power = 0;           // Power going in/out of battery
+uint16_t cell_max_voltage = 3700;       // Stores the highest cell voltage value in the system
+uint16_t cell_min_voltage = 3700;       // Stores the minimum cell voltage value in the system
 bool LFP_Chemistry = false;
 
 // LED parameters

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -2,6 +2,7 @@
 #define BMW_I3_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -17,21 +18,14 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_i3_battery();
 void receive_can_i3_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -2,6 +2,7 @@
 #define CHADEMO_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -17,21 +18,14 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_chademo_battery();
 void receive_can_chademo_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -2,6 +2,7 @@
 #define IMIEV_CZERO_ION_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -17,8 +18,8 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
@@ -28,13 +29,6 @@ extern uint16_t cell_min_voltage;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 extern uint8_t LEDcolor;
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_imiev_battery();
 void receive_can_imiev_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -2,6 +2,7 @@
 #define KIA_HYUNDAI_64_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -17,21 +18,14 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_kiaHyundai_64_battery();
 void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -2,7 +2,7 @@
 #define NISSAN_LEAF_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
-#include "../devboard/config.h"  // Needed for LED defines
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -18,8 +18,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -27,14 +27,6 @@ extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern uint8_t LEDcolor;           //Enum, 0-10
 extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-// Definitions for bms_status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_leaf_battery();
 void receive_can_leaf_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.h
@@ -2,6 +2,7 @@
 #define RENAULT_ZOE_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -17,21 +18,14 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_zoe_battery();
 void receive_can_zoe_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.h
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.h
@@ -5,7 +5,7 @@
 
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
-#include "../devboard/config.h"  // Needed for LED defines
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/mackelec-SerialDataLink/SerialDataLink.h"
 
 //  https://github.com/mackelec/SerialDataLink
@@ -23,8 +23,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -39,14 +39,6 @@ extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
 
 // Parameters to send to the transmitter
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-// Definitions for bms_status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void manageSerialLinkReceiver();
 void update_values_serial_link();

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -2,7 +2,7 @@
 #define TESLA_MODEL_3_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
-#include "../devboard/config.h"  // Needed for LED defines
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -21,8 +21,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -32,14 +32,6 @@ extern uint8_t LEDcolor;           //Enum, 0-10
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 extern bool LFP_Chemistry;
-
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_tesla_model_3_battery();
 void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame);

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -2,7 +2,7 @@
 #define TEST_FAKE_BATTERY_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
-#include "../devboard/config.h"  // Needed for LED defines
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define ABSOLUTE_MAX_VOLTAGE \
@@ -18,8 +18,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -28,13 +28,6 @@ extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 extern uint8_t LEDcolor;                     //Enum, 0-10
-// Definitions for bms_status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_test_battery();
 void receive_can_test_battery(CAN_frame_t rx_frame);

--- a/Software/src/devboard/config.h
+++ b/Software/src/devboard/config.h
@@ -39,4 +39,14 @@
 #define BLUE 3
 #define TEST_ALL_COLORS 10
 
+// Inverter definitions
+#define STANDBY 0
+#define INACTIVE 1
+#define DARKSTART 2
+#define ACTIVE 3
+#define FAULT 4
+#define UPDATING 5
+#define DISCHARGING 1
+#define CHARGING 2
+
 #endif

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -2,6 +2,7 @@
 #define BYD_CAN_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 extern uint16_t SOC;
@@ -12,8 +13,8 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
@@ -22,13 +23,6 @@ extern uint16_t min_voltage;
 extern uint16_t max_voltage;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_can_byd();
 void send_can_byd();

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -33,10 +33,10 @@ void handle_update_data_modbusp201_byd() {
   system_data[0] = 0;  // Id.: p201 Value.: 0 Scaled value.: 0 Comment.: Always 0
   system_data[1] = 0;  // Id.: p202 Value.: 0 Scaled value.: 0 Comment.: Always 0
   system_data[2] =
-      (capacity_Wh_startup);  // Id.: p203 Value.: 32000 Scaled value.: 32kWh Comment.: Capacity rated, maximum value is 60000 (60kWh)
-  system_data[3] = (max_power);  // Id.: p204 Value.: 32000 Scaled value.: 32kWh Comment.: Nominal capacity
+      (capacity_Wh);  // Id.: p203 Value.: 32000 Scaled value.: 32kWh Comment.: Capacity rated, maximum value is 60000 (60kWh)
+  system_data[3] = MAX_POWER;  // Id.: p204 Value.: 32000 Scaled value.: 32kWh Comment.: Nominal capacity
   system_data[4] =
-      (max_power);  // Id.: p205 Value.: 14500 Scaled value.: 30,42kW  Comment.: Max Charge/Discharge Power=10.24kW (lowest value of 204 and 205 will be enforced by Gen24)
+      MAX_POWER;  // Id.: p205 Value.: 14500 Scaled value.: 30,42kW  Comment.: Max Charge/Discharge Power=10.24kW (lowest value of 204 and 205 will be enforced by Gen24)
   system_data[5] =
       (max_voltage);  // Id.: p206 Value.: 3667 Scaled value.: 362,7VDC Comment.: Max Voltage, if higher charging is not possible (goes into forced discharge)
   system_data[6] =
@@ -56,12 +56,12 @@ void handle_update_data_modbusp201_byd() {
 void handle_update_data_modbusp301_byd() {
   // Store the data into the array
   static uint16_t battery_data[24];
-  if (battery_current > 0) {         //Positive value = Charging
-    bms_char_dis_status = 2;         //Charging
-  } else if (battery_current < 0) {  //Negative value = Discharging
-    bms_char_dis_status = 1;         //Discharging
-  } else {                           //battery_current == 0
-    bms_char_dis_status = 0;         //idle
+  if (battery_current == 0) {
+    bms_char_dis_status = STANDBY;
+  } else if (battery_current > 32768) {  //Negative value = Discharging
+    bms_char_dis_status = DISCHARGING;
+  } else {  //Positive value = Charging
+    bms_char_dis_status = CHARGING;
   }
 
   if (bms_status == ACTIVE) {

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -58,7 +58,7 @@ void handle_update_data_modbusp301_byd() {
   static uint16_t battery_data[24];
   if (battery_current == 0) {
     bms_char_dis_status = STANDBY;
-  } else if (battery_current > 32768) {  //Negative value = Discharging
+  } else if (battery_current > 32767) {  //Negative value = Discharging
     bms_char_dis_status = DISCHARGING;
   } else {  //Positive value = Charging
     bms_char_dis_status = CHARGING;

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -1,15 +1,10 @@
 #ifndef BYD_MODBUS_H
 #define BYD_MODBUS_H
 #include <Arduino.h>
+#include "../devboard/config.h"  // Needed for all defines
 
 #define MB_RTU_NUM_VALUES 30000
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
+#define MAX_POWER 40960  //BYD Modbus specific value
 
 extern uint16_t mbPV[MB_RTU_NUM_VALUES];
 extern uint16_t SOC;
@@ -20,12 +15,11 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
-extern uint16_t capacity_Wh_startup;
 extern uint16_t max_power;
 extern uint16_t max_voltage;
 extern uint16_t min_voltage;

--- a/Software/src/inverter/LUNA2000-MODBUS.cpp
+++ b/Software/src/inverter/LUNA2000-MODBUS.cpp
@@ -26,9 +26,9 @@ void handle_update_data_modbus39500() {
   // Store the data into the array
   static uint16_t system_data[26];
   system_data[0] = 0;
-  system_data[1] = capacity_Wh_startup;  //Capacity? 5000 with 5kWh battery
+  system_data[1] = capacity_Wh;  //Capacity? 5000 with 5kWh battery
   system_data[2] = 0;
-  system_data[3] = capacity_Wh_startup;  //Capacity? 5000 with 5kWh battery
+  system_data[3] = capacity_Wh;  //Capacity? 5000 with 5kWh battery
   system_data[4] = 0;
   system_data[5] = 2500;  //???
   system_data[6] = 0;

--- a/Software/src/inverter/LUNA2000-MODBUS.h
+++ b/Software/src/inverter/LUNA2000-MODBUS.h
@@ -1,15 +1,9 @@
 #ifndef LUNA2000_MODBUS_H
 #define LUNA2000_MODBUS_H
 #include <Arduino.h>
+#include "../devboard/config.h"  // Needed for all defines
 
 #define MB_RTU_NUM_VALUES 30000
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 extern uint16_t mbPV[MB_RTU_NUM_VALUES];
 extern uint16_t SOC;
@@ -20,8 +14,8 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/inverter/LUNA2000-MODBUS.h
+++ b/Software/src/inverter/LUNA2000-MODBUS.h
@@ -19,7 +19,6 @@ extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
-extern uint16_t capacity_Wh_startup;
 extern uint16_t max_power;
 extern uint16_t max_voltage;
 extern uint16_t min_voltage;

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -2,6 +2,7 @@
 #define PYLON_CAN_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 extern uint16_t SOC;
@@ -12,8 +13,8 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;
@@ -22,13 +23,6 @@ extern uint16_t min_voltage;
 extern uint16_t max_voltage;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_can_pylon();
 void receive_can_pylon(CAN_frame_t rx_frame);

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
@@ -5,7 +5,7 @@
 
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
-#include "../devboard/config.h"  // Needed for LED defines
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/mackelec-SerialDataLink/SerialDataLink.h"
 
 // These parameters need to be mapped for the inverter
@@ -17,8 +17,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -32,14 +32,6 @@ extern uint16_t CANerror;
 
 // parameters received from receiver
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void manageSerialLinkTransmitter();
 

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -2,6 +2,7 @@
 #define SMA_CAN_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 extern uint16_t SOC;                         //SOC%, 0-100.00 (0-10000)
@@ -12,8 +13,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -24,13 +25,6 @@ extern uint16_t max_voltage;
 extern uint8_t LEDcolor;                     //Enum, 0-10
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_can_sma();
 void send_can_sma();

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -2,6 +2,7 @@
 #define SOFAR_CAN_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 // These parameters need to be mapped for the inverter
@@ -13,8 +14,8 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint16_t bms_status;                  //Enum, 0-5
-extern uint16_t bms_char_dis_status;         //Enum, 0-2
+extern uint8_t bms_status;                   //Enum, 0-5
+extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
@@ -26,13 +27,6 @@ extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 
 extern uint16_t min_voltage;
 extern uint16_t max_voltage;
-// Definitions for BMS status
-#define STANDBY 0
-#define INACTIVE 1
-#define DARKSTART 2
-#define ACTIVE 3
-#define FAULT 4
-#define UPDATING 5
 
 void update_values_can_sofar();
 void send_can_sofar();

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -2,7 +2,7 @@
 #define SOLAX_CAN_H
 #include <Arduino.h>
 #include "../../USER_SETTINGS.h"
-#include "../devboard/config.h"
+#include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "../lib/pierremolinaro-acan2515/ACAN2515.h"
 
@@ -16,8 +16,8 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint16_t bms_status;
-extern uint16_t bms_char_dis_status;
+extern uint8_t bms_status;
+extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;


### PR DESCRIPTION
### What
Noticed by @Cabooman , the `bms_char_dis_status` parameter would never flip correctly between Charging and Discharging, due to u16 / s16 incompability 

### Why
The BYD Modbus handling of this value has been incorrect, which could lead to unwanted desire on inverter side.

### How
This PR fixes the following
- `bms_char_dis_status` parameter now correct depending on current direction flow
- Enumerations added to `bms_char_dis_status` parameter
- Slight memory optimization for `bms_char_dis_status` and `bms_status` variable
- Inverter defines are no longer duplicated in each .header file. Instead all defines to go "../devboard/config.h"