### PR TITLE
Bugfix/stable ota

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -316,6 +316,7 @@ String processor(const String& var) {
 void onOTAStart() {
   // Log when OTA has started
   Serial.println("OTA update started!");
+  ESP32Can.CANStop();
   bms_status = 5;  //Inform inverter that we are updating
   LEDcolor = BLUE;
 }

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -8,6 +8,7 @@
 #include "../../lib/me-no-dev-AsyncTCP/src/AsyncTCP.h"
 #include "../../lib/me-no-dev-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
 #include "../config.h"  // Needed for LED defines
+#include "../../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 extern uint16_t SOC;                         //SOC%, 0-100.00 (0-10000)
 extern uint16_t StateOfHealth;               //SOH%, 0-100.00 (0-10000)

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -7,8 +7,8 @@
 #include "../../lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h"
 #include "../../lib/me-no-dev-AsyncTCP/src/AsyncTCP.h"
 #include "../../lib/me-no-dev-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
-#include "../config.h"  // Needed for LED defines
 #include "../../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "../config.h"  // Needed for LED defines
 
 extern uint16_t SOC;                         //SOC%, 0-100.00 (0-10000)
 extern uint16_t StateOfHealth;               //SOH%, 0-100.00 (0-10000)


### PR DESCRIPTION
# Bug: Unstable OTA update in live setting

## Description
OTA updates work well when not connected to RS485/CAN
 ## Root cause
The CAN functionality is the likely culprit from testing outcomes. Likely, the CAN ISR messes with the OTA routine
## Solution
Disabling the CAN peripheral at OTA-start seems to do the trick in a limited testing setup. Disabling the interrupt could also work but this is easy and enough
